### PR TITLE
feat: group sidebar tables under schemas

### DIFF
--- a/Tusk/Views/Sidebar/SidebarView.swift
+++ b/Tusk/Views/Sidebar/SidebarView.swift
@@ -44,10 +44,8 @@ private struct ConnectionSection: View {
             if $1 == "public" { return false }
             return $0 < $1
         }
-        let tables = all.filter { $0.type == .table }
-        return uniqueSchemas.map { schema in
-            (name: schema, tables: tables.filter { $0.schema == schema })
-        }
+        let tablesBySchema = Dictionary(grouping: all.filter { $0.type == .table }, by: { $0.schema })
+        return uniqueSchemas.map { (name: $0, tables: tablesBySchema[$0] ?? []) }
     }
 
     var body: some View {


### PR DESCRIPTION
## Summary

- Tables in the sidebar are now grouped under their Postgres schema
- `public` schema sorted first, remaining schemas alphabetical
- All schemas collapsed by default — user expands manually
- Schemas with no BASE TABLE entries (e.g. view-only schemas) shown with a muted `empty` pill
- Views remain filtered out

## Test plan

- [ ] Connect to a DB with multiple schemas — verify each appears as a collapsible group
- [ ] Confirm all schemas are collapsed on initial connect
- [ ] Confirm `public` appears first
- [ ] Verify a schema with no tables shows the `empty` pill
- [ ] Expand a schema and select a table — verify detail view loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)