### PR TITLE
fix: dock sidebar with balanced split view style

### DIFF
--- a/Tusk/Views/ContentView.swift
+++ b/Tusk/Views/ContentView.swift
@@ -3,14 +3,17 @@ import SwiftUI
 struct ContentView: View {
     @Environment(AppState.self) private var appState
 
+    @State private var columnVisibility = NavigationSplitViewVisibility.all
+
     var body: some View {
         @Bindable var appState = appState
 
-        NavigationSplitView {
+        NavigationSplitView(columnVisibility: $columnVisibility) {
             SidebarView()
         } detail: {
             DetailView()
         }
+        .navigationSplitViewStyle(.balanced)
         .sheet(isPresented: $appState.isAddingConnection) {
             AddConnectionSheet(connection: nil)
         }


### PR DESCRIPTION
## Summary

- Sidebar was appearing in a floating/overlay style instead of being docked alongside the content
- Applied `.navigationSplitViewStyle(.balanced)` to keep both columns permanently side-by-side
- Set `columnVisibility = .all` so the sidebar is always visible on launch

## Test plan

- [ ] Sidebar is docked and visible on launch
- [ ] Sidebar does not float or overlay the detail area
- [ ] Resizing the window keeps both columns visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)