### PR TITLE
feat: add new SQL file creation to file browser

### DIFF
--- a/Tusk/Views/Sidebar/FileExplorerView.swift
+++ b/Tusk/Views/Sidebar/FileExplorerView.swift
@@ -151,7 +151,7 @@ struct FileExplorerView: View {
         guard !name.isEmpty else { isCreatingFile = false; return }
         // Strip any path separators/traversal — keep only the last component
         name = URL(fileURLWithPath: name).lastPathComponent
-        guard !name.isEmpty else { isCreatingFile = false; return }
+        guard !name.isEmpty, !name.hasPrefix(".") else { isCreatingFile = false; return }
         if !name.lowercased().hasSuffix(".sql") { name += ".sql" }
         let fileURL = currentDirectory.appendingPathComponent(name)
         // Verify the resolved URL stays within currentDirectory


### PR DESCRIPTION
## Summary

- Adds a `+` button to the `FileExplorerView` header with a "New SQL file" tooltip
- Tapping it shows an inline text field at the top of the file list (auto-focused, placeholder `filename.sql`)
- **Enter** commits: auto-appends `.sql` if omitted, creates the empty file on disk, reloads the directory, and opens the file in the query editor
- **Escape** cancels without creating anything
- Empty folder state is suppressed while the inline field is active

## Test plan

- [ ] Click `+` in the file browser header — inline text field appears
- [ ] Type a name without `.sql` extension, press Enter — file is created with `.sql` appended and opens in editor
- [ ] Type a name with `.sql` extension, press Enter — file is created and opens in editor
- [ ] Press Escape — field dismisses, no file created
- [ ] Submit with empty input — field dismisses, no file created
- [ ] Test in an empty folder — list shows the text field instead of "Empty folder"

🤖 Generated with [Claude Code](https://claude.com/claude-code)