### PR TITLE
fix: decode binary date/time values in query and table results

### DIFF
--- a/Tusk/Database/DatabaseClient.swift
+++ b/Tusk/Database/DatabaseClient.swift
@@ -315,11 +315,15 @@ private func pgCellString(bytes: ByteBuffer, dataType: PostgresDataType) -> Stri
         // 8 bytes microseconds since midnight + 4 bytes timezone offset (seconds west of UTC)
         guard let us     = buf.readInteger(as: Int64.self),
               let tzSec  = buf.readInteger(as: Int32.self) else { break }
-        let absOff = abs(Int(tzSec))
-        let sign   = tzSec <= 0 ? "+" : "-"
-        return String(format: "%@%@%02d:%02d",
-                      pgTimeOfDayString(microseconds: us), sign,
-                      absOff / 3600, (absOff % 3600) / 60)
+        let absOff  = abs(Int(tzSec))
+        let sign    = tzSec <= 0 ? "+" : "-"
+        let tzHH    = absOff / 3600
+        let tzMM    = (absOff % 3600) / 60
+        let tzSS    = absOff % 60
+        let tzStr   = tzSS != 0
+            ? String(format: "%02d:%02d:%02d", tzHH, tzMM, tzSS)
+            : String(format: "%02d:%02d", tzHH, tzMM)
+        return "\(pgTimeOfDayString(microseconds: us))\(sign)\(tzStr)"
 
     case .interval:
         // 8 bytes microseconds + 4 bytes days + 4 bytes months


### PR DESCRIPTION
## Summary

- `PostgresQuery(unsafeSQL:)` uses PostgresNIO's extended query protocol, which negotiates **binary format** for results
- Date/time columns (`timestamp`, `timestamptz`, `date`, `time`, `timetz`, `interval`) arrive as raw int64/int32 byte sequences, not UTF-8 — so the previous `getString()` call returned `nil`/garbage, leaving cells blank in both the query results grid and the table data browser
- Adds `pgCellString(bytes:dataType:)` which decodes each binary layout and formats it as a readable string; all other types fall through to the existing UTF-8 text decoding

## Decoding added

| PostgreSQL type | Binary layout | Example output |
|---|---|---|
| `timestamp` / `timestamptz` | int64 µs since 2000-01-01 UTC | `2024-01-15 10:30:00.5` |
| `date` | int32 days since 2000-01-01 | `2024-01-15` |
| `time` | int64 µs since midnight | `10:30:00` |
| `timetz` | int64 µs + int32 tz offset | `10:30:00+05:30` |
| `interval` | int64 µs + int32 days + int32 months | `1 year 3 days 02:00:00` |

Trailing fractional-second zeros are trimmed (e.g. `.500000` → `.5`).

## Test plan

- [ ] Query a table with `timestamp` / `timestamptz` columns — values render correctly
- [ ] Query a table with `date` columns — values render correctly
- [ ] Query a table with `time` / `timetz` columns — values render correctly
- [ ] Query a table with `interval` columns — values render correctly
- [ ] Timestamps with sub-second precision show trimmed fractional seconds
- [ ] NULL date/time values still render as `NULL`
- [ ] Non-date columns (text, int, bool) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)