### PR TITLE
feat: truncate long cell values and show full content on double-click

### DIFF
--- a/Tusk/Views/Main/QueryEditorView.swift
+++ b/Tusk/Views/Main/QueryEditorView.swift
@@ -230,7 +230,7 @@ struct QueryEditorView: View {
 struct ResultsGrid: View {
     let result: QueryResult
 
-    @State private var expandedCell: String? = nil
+    @State private var expandedCell: CellDetailContent? = nil
 
     var body: some View {
         GeometryReader { geo in
@@ -265,7 +265,7 @@ struct ResultsGrid: View {
                                         : Color(nsColor: .controlAlternatingRowBackgroundColors[1]))
                                     .border(Color(nsColor: .separatorColor), width: 0.5)
                                     .onTapGesture(count: 2) {
-                                        expandedCell = cell.displayValue
+                                        expandedCell = CellDetailContent(id: "\(rowIndex):\(colIndex)", value: cell.displayValue)
                                     }
                                     .contextMenu {
                                         Button("Copy") {
@@ -273,7 +273,7 @@ struct ResultsGrid: View {
                                             NSPasteboard.general.setString(cell.displayValue, forType: .string)
                                         }
                                         Button("View Full Value") {
-                                            expandedCell = cell.displayValue
+                                            expandedCell = CellDetailContent(id: "\(rowIndex):\(colIndex)", value: cell.displayValue)
                                         }
                                     }
                             }
@@ -288,10 +288,7 @@ struct ResultsGrid: View {
             }
         }
         .background(Color(nsColor: .textBackgroundColor))
-        .sheet(item: Binding(
-            get: { expandedCell.map { CellDetailContent(value: $0) } },
-            set: { if $0 == nil { expandedCell = nil } }
-        )) { content in
+        .sheet(item: $expandedCell) { content in
             CellDetailView(value: content.value)
         }
     }
@@ -300,7 +297,7 @@ struct ResultsGrid: View {
 // MARK: - Cell detail sheet
 
 private struct CellDetailContent: Identifiable {
-    let id = UUID()
+    let id: String   // "\(rowIndex):\(colIndex)" — stable across re-renders
     let value: String
 }
 


### PR DESCRIPTION
## Summary

- All cells in `ResultsGrid` now render with `lineLimit(1)` + `truncationMode(.tail)` — rows stay uniform height and long values trail off with `…`
- Double-clicking any cell opens a `CellDetailView` sheet with the full raw value
- "View Full Value" also added to the existing right-click context menu
- `CellDetailView` displays the full value in a scrollable, selectable monospaced text area — works well for text, JSON, XML, UUIDs, and any other long-form content
- Copy button and dismiss button included in the sheet

## Test plan

- [ ] Query a table with long `text` or `varchar` columns — cells truncate to a single line with `…`
- [ ] Double-click a truncated cell — sheet opens with full content
- [ ] Right-click a cell → "View Full Value" — sheet opens with full content
- [ ] Copy button in sheet copies the full value to clipboard
- [ ] Short values (IDs, dates, booleans) are unaffected visually
- [ ] NULL cells still render with tertiary style
- [ ] Sheet works for JSON, UUIDs, timestamps, and other types

🤖 Generated with [Claude Code](https://claude.com/claude-code)