### PR TITLE
fix: bump app version to 1.1.0

### DIFF
--- a/Tusk/Resources/Info.plist
+++ b/Tusk/Resources/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>1.1.0</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>2</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>NSHumanReadableDescription</key>

--- a/Tusk/Views/About/AboutView.swift
+++ b/Tusk/Views/About/AboutView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct AboutView: View {
-    private let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0"
+    private let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
 
     @State private var updateStatus: UpdateStatus = .idle
 

--- a/project.yml
+++ b/project.yml
@@ -24,8 +24,8 @@ targets:
       properties:
         CFBundleName: Tusk
         CFBundleDisplayName: Tusk
-        CFBundleShortVersionString: "1.0"
-        CFBundleVersion: "1"
+        CFBundleShortVersionString: "1.1.0"
+        CFBundleVersion: "2"
         LSMinimumSystemVersion: "$(MACOSX_DEPLOYMENT_TARGET)"
         NSHumanReadableDescription: A minimal, privacy-first PostgreSQL client for macOS.
         NSPrincipalClass: NSApplication


### PR DESCRIPTION
## Summary

- `CFBundleShortVersionString` updated from `1.0` → `1.1.0` in `Info.plist` and `project.yml`
- `CFBundleVersion` bumped from `1` → `2`
- Removed hardcoded `"1.0"` fallback string in `AboutView.swift` — now falls back to `"unknown"` if the bundle key is missing

## Test plan

- [ ] Build and run the app
- [ ] Open About panel — confirm it shows "Version 1.1.0"

🤖 Generated with [Claude Code](https://claude.com/claude-code)