### PR TITLE
fix: use unqualified table name in data browser filter cast

### DIFF
--- a/Tusk/Views/Main/DataBrowserView.swift
+++ b/Tusk/Views/Main/DataBrowserView.swift
@@ -143,7 +143,7 @@ struct DataBrowserView: View {
         var sql = "SELECT * FROM \(qualifiedName)"
 
         if !filterText.isEmpty {
-            sql += " WHERE \(qualifiedName)::text ILIKE '%\(filterText)%'"
+            sql += " WHERE \"\(tableName)\"::text ILIKE '%\(filterText)%'"
         }
 
         if let col = sortColumn {


### PR DESCRIPTION
## Summary

Filtering in the Data tab was broken for any table in a non-default schema (or any schema-qualified table), producing:

> Query failed: missing FROM-clause entry for table "public"

**Root cause:** The filter `WHERE` clause was using `qualifiedName` (`"schema"."table"::text`) for the row cast. PostgreSQL interprets the schema-qualified form as a column reference (`"public"` = table, `"auth_permission"` = column), not a row type cast — so it complains that `"public"` isn't in the `FROM` clause.

**Fix:** Use just the unqualified table name (`"tableName"::text`), which PostgreSQL correctly resolves to the row's composite type.

**Before:**
```sql
SELECT * FROM "public"."auth_permission"
WHERE "public"."auth_permission"::text ILIKE '%change%'
```

**After:**
```sql
SELECT * FROM "public"."auth_permission"
WHERE "auth_permission"::text ILIKE '%change%'
```

## Test plan

- [ ] Open a table in the Data tab and type in the filter field — results should filter correctly
- [ ] Verify filtering works across schemas (public and non-public)

🤖 Generated with [Claude Code](https://claude.com/claude-code)