### PR TITLE
fix: schema rows from different connections conflating @State

### DIFF
--- a/Tusk/Views/Sidebar/SidebarView.swift
+++ b/Tusk/Views/Sidebar/SidebarView.swift
@@ -56,7 +56,7 @@ private struct ConnectionSection: View {
 
     /// All schemas present in the cache, public first then alphabetical.
     /// Each entry pairs a schema name with its BASE TABLE items only.
-    var schemas: [(name: String, tables: [TableInfo])] {
+    var schemas: [(id: String, name: String, tables: [TableInfo])] {
         let all = appState.schemaTables[connection.id] ?? []
         let uniqueSchemas = Array(Set(all.map { $0.schema })).sorted {
             if $0 == "public" { return true }
@@ -64,13 +64,16 @@ private struct ConnectionSection: View {
             return $0 < $1
         }
         let tablesBySchema = Dictionary(grouping: all.filter { $0.type == .table }, by: { $0.schema })
-        return uniqueSchemas.map { (name: $0, tables: tablesBySchema[$0] ?? []) }
+        // Include connection.id in the row ID so that identically-named schemas
+        // across different connections get distinct SwiftUI identities in the
+        // flattened List — otherwise @State (isExpanded) is shared between them.
+        return uniqueSchemas.map { (id: "\(connection.id)-\($0)", name: $0, tables: tablesBySchema[$0] ?? []) }
     }
 
     var body: some View {
         Section {
             if isConnected {
-                ForEach(schemas, id: \.name) { schema in
+                ForEach(schemas, id: \.id) { schema in
                     SchemaRow(schema: schema.name, tables: schema.tables, connection: connection)
                 }
             }


### PR DESCRIPTION
## Root cause

`ForEach(schemas, id: \.name)` used only the schema name as the SwiftUI row identity. macOS `List` flattens its sections internally, so when two connections both have a `"public"` schema, SwiftUI sees two rows with the identical ID `"public"` in the flat list and conflates their `@State`. Since `SchemaRow` holds `@State private var isExpanded`, both rows end up sharing the same expansion state — tapping connection A's schema either expands connection B's schema or does nothing.

## Fix

Added `id: String` (= `"\(connection.id)-\(schemaName)"`) to the schemas tuple and switched `ForEach` to `id: \.id`. Every schema row now has a globally unique identity within the `List` regardless of name collisions across connections.

## Test plan

- [ ] Connect two databases that share schema names (e.g. both have `public`)
- [ ] Verify expanding/collapsing schema rows on connection A does not affect connection B
- [ ] Verify expanding/collapsing works correctly on both connections independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)