### PR TITLE
perf: keep tab views alive across tab switches using ZStack

### DIFF
--- a/Tusk/Views/ContentView.swift
+++ b/Tusk/Views/ContentView.swift
@@ -44,6 +44,11 @@ struct DetailView: View {
         }
         .environment(\.font, .system(size: contentFontSize, design: contentFontDesign.design))
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .onChange(of: appState.activeDetailTabID) {
+            // Resign AppKit first responder (e.g. NSTextView in SQLTextEditor) when
+            // switching tabs so hidden editors don't continue receiving keyboard input.
+            NSApp.keyWindow?.makeFirstResponder(nil)
+        }
     }
 
     @ViewBuilder
@@ -56,6 +61,7 @@ struct DetailView: View {
                     tabContent(for: tab)
                         .opacity(tab.id == appState.activeDetailTabID ? 1 : 0)
                         .allowsHitTesting(tab.id == appState.activeDetailTabID)
+                        .accessibilityHidden(tab.id != appState.activeDetailTabID)
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)


### PR DESCRIPTION
## Summary
The detail pane previously rendered only the active tab's view, tearing down and rebuilding the entire view tree on every tab switch. This replaces the switch-based renderer with a `ZStack` over all open tabs — each view stays in the hierarchy permanently, with only the active one visible and interactive. Tab switching now preserves all `@State` including scroll positions, sub-tab selection, and editor state.

## Changes
- `ContentView.swift` — `DetailView.activeContent`: replaced `if/switch` single-view renderer with `ZStack { ForEach(appState.openTabs) }` + extracted `tabContent(for:)` helper; removed `.id(connID)` and `.id(queryTab.id)` modifiers

## What was not changed
- `DataBrowserState` and `QueryTab` result persistence (#53/#56) — still correct and in place
- `DetailTabBar`, `DetailTabItem` — unchanged
- `WelcomeView` — kept outside the ZStack, shown only when `openTabs` is empty
- All sidebar, connection, and settings logic — untouched

## How to test
1. Open a table tab, navigate to the **Data** sub-tab — data loads
2. Switch to a query editor tab, switch back — **Data** sub-tab is still selected (not reset to Columns)
3. Scroll down in a large result set, switch tabs, switch back — scroll position preserved
4. Open 3+ tabs, switch between them rapidly — no loading spinners, instant switch
5. Close a tab — remaining tabs unaffected
6. Open app with no tabs — WelcomeView shown correctly
7. Connect to a DB, open a table while connection is in progress — "Connecting…" placeholder shown, updates when ready

Closes #57
Closes #59