### PR TITLE
feat: cmd+, shortcut to toggle settings popover

### DIFF
--- a/Tusk/AppState.swift
+++ b/Tusk/AppState.swift
@@ -29,6 +29,7 @@ final class AppState {
 
     // MARK: - UI state
     var isAddingConnection = false
+    var isShowingSettings = false
     var editingConnection: Connection? = nil
     var connectingIDs: Set<UUID> = []
 

--- a/Tusk/Views/ContentView.swift
+++ b/Tusk/Views/ContentView.swift
@@ -11,7 +11,7 @@ struct ContentView: View {
         @Bindable var appState = appState
 
         NavigationSplitView(columnVisibility: $columnVisibility) {
-            SidebarView()
+            SidebarView(appState: appState)
         } detail: {
             DetailView()
         }

--- a/Tusk/Views/Main/TuskCommands.swift
+++ b/Tusk/Views/Main/TuskCommands.swift
@@ -12,6 +12,13 @@ struct TuskCommands: Commands {
             }
         }
 
+        CommandGroup(replacing: .appSettings) {
+            Button("Settings…") {
+                appState.isShowingSettings.toggle()
+            }
+            .keyboardShortcut(",", modifiers: .command)
+        }
+
         CommandGroup(after: .newItem) {
             Button("New Connection…") {
                 appState.isAddingConnection = true

--- a/Tusk/Views/Sidebar/SidebarView.swift
+++ b/Tusk/Views/Sidebar/SidebarView.swift
@@ -1,10 +1,9 @@
 import SwiftUI
 
 struct SidebarView: View {
-    @Environment(AppState.self) private var appState
+    @Bindable var appState: AppState
     @AppStorage("tusk.sidebar.fontSize")    private var sidebarFontSize   = 13.0
     @AppStorage("tusk.sidebar.fontDesign") private var sidebarFontDesign: TuskFontDesign = .sansSerif
-    @State private var showingSettings = false
 
     var body: some View {
         VSplitView {
@@ -41,12 +40,12 @@ struct SidebarView: View {
         .toolbar {
             ToolbarItem(placement: .automatic) {
                 Button {
-                    showingSettings.toggle()
+                    appState.isShowingSettings.toggle()
                 } label: {
                     Image(systemName: "gearshape")
                 }
                 .help("Appearance settings")
-                .popover(isPresented: $showingSettings, arrowEdge: .bottom) {
+                .popover(isPresented: $appState.isShowingSettings, arrowEdge: .bottom) {
                     SettingsPopover()
                 }
             }


### PR DESCRIPTION
## Summary
Adds `cmd+,` as a global keyboard shortcut to toggle the settings popover open/closed, following the standard macOS convention for preferences/settings. Pressing the shortcut again closes the popover, making it a true toggle.

## Changes
- `AppState.swift`: added `isShowingSettings` to UI state
- `SidebarView.swift`: switched from local `@State` to `appState.isShowingSettings` so the popover state is accessible globally
- `ContentView.swift`: pass `appState` explicitly to `SidebarView` (required by the `@Bindable` init)
- `TuskCommands.swift`: added `CommandGroup(replacing: .appSettings)` with `cmd+,` binding

## What was not changed
`SettingsPopover` content is untouched. No new window or Settings scene was introduced.

## How to test
1. Launch the app
2. Press `cmd+,` — the settings popover opens
3. Press `cmd+,` again — it closes
4. Click the gear toolbar button — still works as before

Closes #62