### PR TITLE
feat: keyboard navigation for ResultsGrid row selection

### DIFF
--- a/Tusk/Views/Main/QueryEditorView.swift
+++ b/Tusk/Views/Main/QueryEditorView.swift
@@ -426,6 +426,7 @@ struct ResultsGrid: View {
         if flags.contains(.command) {
             if selectedRows.contains(rowIndex) {
                 selectedRows.remove(rowIndex)
+                if lastSelectedRow == rowIndex { lastSelectedRow = nil }
             } else {
                 selectedRows.insert(rowIndex)
                 lastSelectedRow = rowIndex


### PR DESCRIPTION
## Summary
Adds full keyboard navigation to `ResultsGrid` on top of the click-based selection from #51. Users can navigate and extend the selection without touching the mouse, matching standard macOS data grid behaviour.

## Changes
- `QueryEditorView.swift` (`ResultsGrid`):
  - New state: `@FocusState isFocused`, `@AppStorage contentFontSize`, `@State scrollProxy`, `@State keyboardCursor`
  - Wrapped `LazyVStack` in `ScrollViewReader`; each row `HStack` gets `.id(rowIndex)` for `scrollTo`
  - `.focusable()` + `.focused($isFocused)` + `.onKeyPress(...)` on the `ScrollView`
  - Row tap now sets `isFocused = true` and `keyboardCursor`
  - `handleKeyNavigation(press:viewHeight:)` — moves cursor, updates `selectedRows` (with or without shift range extension), scrolls viewport
  - `handleSelectAll()` — `Cmd+A` selects all rows
  - `keyboardCursor` cleared alongside `selectedRows` on result reload

## What was not changed
- Home/End keys — out of scope
- Drag-to-select — out of scope
- All files other than `QueryEditorView.swift`

## How to test
1. Run a query or open a table — click any row to focus the grid
2. Press `↑`/`↓` — selection moves one row, viewport scrolls to follow
3. Press `Page Down`/`Page Up` — selection jumps by ~one page
4. Hold `Shift` while pressing arrow or page keys — selection range extends from the anchor
5. Press `Cmd+A` — all rows are selected
6. Navigate to a new page or run a new query — selection and cursor clear

Closes #66