### PR TITLE
feat: JSON/JSONB cell detail tree viewer

### DIFF
--- a/Tusk/Views/Main/QueryEditorView.swift
+++ b/Tusk/Views/Main/QueryEditorView.swift
@@ -523,12 +523,13 @@ struct CellDetailView: View {
     }
 
     var body: some View {
+        let json = parsedJSON   // parse exactly once per render
         VStack(spacing: 0) {
             HStack {
                 Text("Cell Value")
                     .fontWeight(.semibold)
                 Spacer()
-                if parsedJSON != nil {
+                if json != nil {
                     Picker("", selection: $showTree) {
                         Text("Tree").tag(true)
                         Text("Raw").tag(false)
@@ -557,10 +558,10 @@ struct CellDetailView: View {
 
             Divider()
 
-            if let json = parsedJSON, showTree {
-                JSONTreeView(value: json)
+            if let j = json, showTree {
+                JSONTreeView(value: j)
             } else {
-                let displayText = parsedJSON != nil ? prettyJSON : value
+                let displayText = json != nil ? prettyJSON : value
                 ScrollView([.horizontal, .vertical]) {
                     if displayText.isEmpty {
                         Text("''")


### PR DESCRIPTION
## Summary
Adds an interactive expandable tree view to the cell detail sheet for `json` and `jsonb` columns. The column's PostgreSQL type is now passed through to `CellDetailView`, which detects json/jsonb and attempts to parse the value. On success, a **Tree | Raw** segmented picker appears; tree view uses recursive `DisclosureGroup` nodes with colour-coded primitives. Non-JSON columns and parse failures fall back to the existing raw text view unchanged.

## Changes
- `CellDetailContent`: added `columnDataType: String` field
- `ResultsGrid` (two call sites): pass `result.columns[colIndex].dataType` when opening cell detail
- `CellDetailView`: added `columnDataType` param, `showTree` state, `parsedJSON` / `prettyJSON` computed properties, conditional Tree/Raw picker and tree view
- New private types: `JSONValue` (indirect enum), `parseJSONValue`, `convertAny`, `JSONTreeView`, `JSONNodeView`

## What was not changed
`QueryResult.swift`, `DatabaseClient.swift`, `DataBrowserView.swift`. Copy button always copies the original raw value string.

## How to test
1. Connect to a database with a `json` or `jsonb` column
2. Run a query that returns JSON values
3. Double-click a JSON cell → sheet opens in **Tree** mode with expandable nodes
4. Click **Raw** → pretty-printed JSON text
5. Click **Copy** → pasteboard contains original raw value
6. Open a cell from a non-JSON column → no picker, existing raw view

Closes #44