### PR TITLE
feat: auto-refresh schema after DDL queries

### DIFF
--- a/Tusk/Views/Main/QueryEditorView.swift
+++ b/Tusk/Views/Main/QueryEditorView.swift
@@ -414,7 +414,7 @@ struct QueryEditorView: View {
             return ddlPrefixes.contains { prefix.hasPrefix($0) }
         }
         if hasDDL,
-           let connID = appState.queryTabs.first(where: { $0.id == tab.id })?.connectionID,
+           let connID = liveConnectionID,
            let connection = appState.connections.first(where: { $0.id == connID }) {
             Task { try? await appState.refreshSchema(for: connection) }
         }


### PR DESCRIPTION
## Summary
After running a query that includes a `CREATE`, `DROP`, or `ALTER` statement, the sidebar schema tree now refreshes automatically. Previously users had to manually trigger Refresh Schema after any DDL change — this removes that friction entirely.

## Changes
- `QueryEditorView.swift`: post-execution DDL scan; fire-and-forget `refreshSchema` if any `.ok` entry has a CREATE/DROP/ALTER prefix

## What was not changed
- No changes to `AppState`, `DatabaseClient`, or sidebar views
- DML statements (INSERT/UPDATE/DELETE) do not trigger a refresh
- Refresh errors are swallowed — no UI disruption

## How to test
1. Connect to a database
2. Run `CREATE TABLE test_ddl (id serial primary key)` — sidebar should show the new table automatically
3. Run `DROP TABLE test_ddl` — sidebar should remove it automatically
4. Run `INSERT INTO some_table ...` — sidebar should NOT refresh (no schema change)

Closes #80