### PR TITLE
feat: zoom and pan for Relations view

### DIFF
--- a/Tusk/Views/Main/RelationsView.swift
+++ b/Tusk/Views/Main/RelationsView.swift
@@ -82,7 +82,9 @@ struct RelationsView: View {
         }
         .task(id: "\(schemaName).\(tableName)") {
             scale = 1.0
+            gestureScale = 1.0
             offset = .zero
+            gestureOffset = .zero
             await loadRelations()
         }
     }


### PR DESCRIPTION
## Summary
- Pinch-to-zoom via `MagnificationGesture` (clamped 0.3–3.0×)
- Drag-to-pan via `DragGesture`
- Double-tap to reset scale and position
- `−` / `↺` / `+` zoom controls overlay in bottom-trailing corner
- Auto-scale initial zoom for dense graphs (>6 edges: scale = max(0.4, 6/n))
- Scale and offset reset on table switch

## Test plan
- [ ] `+` / `−` buttons zoom in and out, clamped at 0.3× and 3.0×
- [ ] `↺` resets scale and position
- [ ] Pinch-to-zoom works on trackpad
- [ ] Drag pans the diagram
- [ ] Double-tap resets scale and position
- [ ] Table with >6 relations opens auto-scaled
- [ ] Switching tables resets zoom and pan

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)