### PR TITLE
feat: resizable columns, sortable headers, and persistent column widths

### DIFF
--- a/Tusk/Views/Main/DataBrowserView.swift
+++ b/Tusk/Views/Main/DataBrowserView.swift
@@ -58,7 +58,7 @@ struct DataBrowserView: View {
                     } else {
                         ResultsGrid(
                             result: result,
-                            columnWidthsPersistenceKey: "tusk.colwidths.\(connectionID).\(schemaName).\(tableName)",
+                            columnWidthsPersistenceKey: "tusk.colwidths.\(connectionID)\u{0}\(schemaName)\u{0}\(tableName)",
                             copyAsInsert: isView ? nil : { rows in
                                 copyRowsAsInsert(schema: schemaName, table: tableName, columns: result.columns, rows: rows)
                             },
@@ -95,6 +95,8 @@ struct DataBrowserView: View {
         .task { if state.result == nil { triggerLoad() } }
         .onChange(of: schemaName + "." + tableName) { _, _ in
             state.offset = 0
+            sortColumn = nil
+            sortAscending = true
             triggerLoad()
         }
     }
@@ -258,7 +260,7 @@ struct DataBrowserView: View {
         }
 
         if let col = sortColumn {
-            sql += " ORDER BY \"\(col)\" \(sortAscending ? "ASC" : "DESC")"
+            sql += " ORDER BY \(quoteIdentifier(col)) \(sortAscending ? "ASC" : "DESC")"
         }
 
         sql += " LIMIT \(pageSize) OFFSET \(state.offset)"

--- a/Tusk/Views/Main/QueryEditorView.swift
+++ b/Tusk/Views/Main/QueryEditorView.swift
@@ -950,10 +950,8 @@ struct ResultsGrid: View {
                                             onSortByColumn?(col.name)
                                         }
                                         .onHover { inside in
-                                            if inside && onSortByColumn != nil {
-                                                NSCursor.pointingHand.push()
-                                            } else {
-                                                NSCursor.pop()
+                                            if onSortByColumn != nil {
+                                                if inside { NSCursor.pointingHand.push() } else { NSCursor.pop() }
                                             }
                                         }
 


### PR DESCRIPTION
## Summary
- Drag-to-resize column handles in the data grid (both data browser and query results)
- Clickable column headers for sorting in the data browser
- Column widths persist per table across sessions

## Changes

### Column resizing (#110)
- Each column header has a 6px drag handle on its right edge
- `resizeLeftRight` cursor on hover
- Minimum column width 50pt
- Applies to both data browser and query results tabs

### Column width persistence (#110)
- Widths saved to UserDefaults keyed by `connection + schema + table`
- Stored by column name — survives schema changes gracefully (new columns get default width, removed columns ignored)
- Query results tabs remain ephemeral (no persistence key)

### Sortable columns (#111)
- Click a column header in the data browser to sort ascending
- Click again → descending (↓ indicator), click again → clear sort
- `↑` / `↓` indicator in active header
- Re-fetches via existing `ORDER BY` query builder
- Disabled for views; not available in query results tabs

## Test plan
- [ ] Drag column header edge → column resizes
- [ ] Resize a column, close and reopen the table → width restored
- [ ] Different tables have independent widths
- [ ] Click column header in data browser → sorts ascending with ↑
- [ ] Click again → descending with ↓; click again → sort cleared
- [ ] Views: no sort on column headers
- [ ] Query results: no sort, column widths reset per result

Closes #110, #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)