### PR TITLE
fix: select row on mouse down instead of mouse up (#115)

### DIFF
--- a/Tusk/Views/Main/QueryEditorView.swift
+++ b/Tusk/Views/Main/QueryEditorView.swift
@@ -899,6 +899,7 @@ struct ResultsGrid: View {
                                     DragGesture(minimumDistance: 0)
                                         .onChanged { value in
                                             guard value.translation == .zero else { return }
+                                            guard !NSEvent.modifierFlags.contains(.control) else { return }
                                             isFocused = true
                                             handleRowTap(rowIndex: rowIndex)
                                         }


### PR DESCRIPTION
## Summary
- Replaces `.onTapGesture` with `simultaneousGesture(DragGesture(minimumDistance: 0))` so row selection fires on mouse down, matching native AppKit `NSTableView` behaviour
- A `translation == .zero` guard ensures `handleRowTap` fires exactly once per press and not repeatedly during a drag
- Double-click-to-edit is unaffected via `simultaneousGesture`

## Test plan
- [ ] Clicking a row selects it immediately on mouse down (no visible delay)
- [ ] Double-click on a cell still opens the inline editor
- [ ] ⌘-click toggles individual rows correctly
- [ ] ⇧-click extends the selection range correctly
- [ ] Right-click context menu still appears on unselected rows

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)