### PR TITLE
feat: rename table and column inline (#119)

### DIFF
--- a/Tusk/Views/Main/TableDetailView.swift
+++ b/Tusk/Views/Main/TableDetailView.swift
@@ -13,6 +13,7 @@ struct TableDetailView: View {
     enum Tab { case columns, keys, relations, indexes, triggers, ddl, data }
 
     @State private var selectedTab: Tab = .columns
+    @State private var selectedColumnIDs: Set<String> = []
     @State private var columns: [ColumnInfo] = []
     @State private var foreignKeys: [ForeignKeyInfo] = []
     @State private var isLoadingMeta = false
@@ -162,7 +163,7 @@ struct TableDetailView: View {
             if isLoadingMeta {
                 ProgressView("Loading…").frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
-                Table(columns) {
+                Table(columns, selection: $selectedColumnIDs) {
                     TableColumn("Column") { col in
                         HStack(spacing: 4) {
                             if col.isPrimaryKey {
@@ -210,7 +211,7 @@ struct TableDetailView: View {
         alert.window.initialFirstResponder = field
 
         guard alert.runModal() == .alertFirstButtonReturn else { return }
-        let newName = field.stringValue.trimmingCharacters(in: .whitespaces)
+        let newName = field.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !newName.isEmpty, newName != col.name else { return }
 
         Task {

--- a/Tusk/Views/Sidebar/SidebarView.swift
+++ b/Tusk/Views/Sidebar/SidebarView.swift
@@ -321,7 +321,7 @@ private struct SchemaRow: View {
         alert.window.initialFirstResponder = field
 
         guard alert.runModal() == .alertFirstButtonReturn else { return }
-        let newName = field.stringValue.trimmingCharacters(in: .whitespaces)
+        let newName = field.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !newName.isEmpty, newName != table.name else { return }
 
         Task {
@@ -336,6 +336,9 @@ private struct SchemaRow: View {
                     appState.openOrActivateTableTab(connectionID: connection.id, schema: table.schema, tableName: newName)
                 }
                 try? await appState.refreshSchema(for: connection)
+                if appState.schemaTableSizes[connection.id] != nil {
+                    await appState.loadTableSizes(for: connection)
+                }
             } catch {
                 let err = NSAlert()
                 err.messageText = "Rename Failed"


### PR DESCRIPTION
## Summary
- Right-click any table in the sidebar → **Rename…** → native macOS dialog → executes `ALTER TABLE … RENAME TO …` → refreshes schema tree and reopens the tab with the new name
- Right-click any column in the Columns tab → **Rename…** → same dialog → reloads column metadata

## Approach
Uses `NSAlert` with an `NSTextField` accessory instead of SwiftUI sheets. SwiftUI `.sheet` inside `List` rows is unreliable on macOS — closures aren't `Equatable` so `onDismiss` fires spuriously on every `@Observable` re-render, causing infinite loops. `NSAlert.runModal()` is synchronous and has no lifecycle issues.

## Test plan
- [ ] Rename a table with no open tab → sidebar updates
- [ ] Rename a table with an open tab → old tab closes, new tab opens with updated name
- [ ] Rename the same table multiple times in a row → each rename works correctly
- [ ] Rename a column → Columns tab reloads with new name
- [ ] Cancel the rename dialog → nothing changes
- [ ] Rename fails (e.g. name conflict) → error alert shown, nothing changes

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)