### PR TITLE
feat: edit column type, default, and nullability from Columns tab (#122)

### DIFF
--- a/Tusk/Views/Main/TableDetailView.swift
+++ b/Tusk/Views/Main/TableDetailView.swift
@@ -287,22 +287,29 @@ struct TableDetailView: View {
                 let t = "\(quoteIdentifier(schemaName)).\(quoteIdentifier(tableName))"
                 let c = quoteIdentifier(col.name)
 
-                if typeChanged {
-                    _ = try await client.query("ALTER TABLE \(t) ALTER COLUMN \(c) TYPE \(newType);")
-                }
-                if defaultChanged {
-                    if newDefault.isEmpty {
-                        _ = try await client.query("ALTER TABLE \(t) ALTER COLUMN \(c) DROP DEFAULT;")
-                    } else {
-                        _ = try await client.query("ALTER TABLE \(t) ALTER COLUMN \(c) SET DEFAULT \(newDefault);")
+                _ = try await client.query("BEGIN;")
+                do {
+                    if typeChanged {
+                        _ = try await client.query("ALTER TABLE \(t) ALTER COLUMN \(c) TYPE \(newType);")
                     }
-                }
-                if nullableChanged {
-                    if newNullable {
-                        _ = try await client.query("ALTER TABLE \(t) ALTER COLUMN \(c) DROP NOT NULL;")
-                    } else {
-                        _ = try await client.query("ALTER TABLE \(t) ALTER COLUMN \(c) SET NOT NULL;")
+                    if defaultChanged {
+                        if newDefault.isEmpty {
+                            _ = try await client.query("ALTER TABLE \(t) ALTER COLUMN \(c) DROP DEFAULT;")
+                        } else {
+                            _ = try await client.query("ALTER TABLE \(t) ALTER COLUMN \(c) SET DEFAULT \(newDefault);")
+                        }
                     }
+                    if nullableChanged {
+                        if newNullable {
+                            _ = try await client.query("ALTER TABLE \(t) ALTER COLUMN \(c) DROP NOT NULL;")
+                        } else {
+                            _ = try await client.query("ALTER TABLE \(t) ALTER COLUMN \(c) SET NOT NULL;")
+                        }
+                    }
+                    _ = try await client.query("COMMIT;")
+                } catch {
+                    try? await client.query("ROLLBACK;")
+                    throw error
                 }
                 await loadMeta()
             } catch {


### PR DESCRIPTION
## Summary
- Right-click any column in the Columns tab → **Edit…** opens a dialog pre-filled with the column's current type, default value, and nullable state
- Only changed attributes generate SQL — each as a separate `ALTER TABLE … ALTER COLUMN …` statement so Postgres can surface per-attribute errors clearly
- Hidden for views

## SQL generated
| Change | Statement |
|--------|-----------|
| Type | `ALTER COLUMN c TYPE newtype` |
| Default set | `ALTER COLUMN c SET DEFAULT val` |
| Default cleared | `ALTER COLUMN c DROP DEFAULT` |
| Nullable | `ALTER COLUMN c DROP NOT NULL` |
| Not null | `ALTER COLUMN c SET NOT NULL` |

## Test plan
- [ ] Right-click a column → Edit… → change type → Apply → column reloads with new type
- [ ] Change default value → Apply → Default column updates
- [ ] Clear default field → Apply → default dropped
- [ ] Toggle nullable → Apply → Nullable column updates
- [ ] Change multiple attributes at once → all statements execute
- [ ] Invalid type (e.g. "badtype") → error alert shown, no partial changes committed
- [ ] Cancel → nothing changes
- [ ] Edit… is absent on views

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)