### PR TITLE
feat: add/drop columns from Columns tab (#118)

### DIFF
--- a/Tusk/Views/Main/TableDetailView.swift
+++ b/Tusk/Views/Main/TableDetailView.swift
@@ -201,7 +201,7 @@ struct TableDetailView: View {
                         }
                     }
                     .contextMenu(forSelectionType: String.self) { ids in
-                        if !isView, let id = ids.first,
+                        if !isView, ids.count == 1, let id = ids.first,
                            let col = columns.first(where: { $0.id == id }) {
                             Button("Rename…")      { renameColumn(col) }
                             Button("Edit…")        { editColumn(col) }
@@ -396,6 +396,18 @@ struct TableDetailView: View {
         let nullable   = nullableCheck.state == .on
 
         guard !name.isEmpty, !type.isEmpty else { return }
+
+        let dangerousTokens = [";", "--", "/*", "*/"]
+        for input in [type, defaultVal] where !input.isEmpty {
+            if dangerousTokens.contains(where: { input.contains($0) }) {
+                let err = NSAlert()
+                err.messageText = "Invalid Input"
+                err.informativeText = "Type and default value must not contain SQL metacharacters (;  --  /*  */)."
+                err.alertStyle = .warning
+                err.runModal()
+                return
+            }
+        }
 
         Task {
             do {


### PR DESCRIPTION
## Summary
- Adds a "+" toolbar button to the Columns tab that opens a dialog (name, type, default, nullable) and executes `ALTER TABLE … ADD COLUMN`
- Adds "Drop Column…" to the column context menu with a confirmation alert before executing `ALTER TABLE … DROP COLUMN`
- Both actions are hidden for views; Postgres errors are surfaced via alert

## Issues
Closes #118

## Test plan
- Open a table → Columns tab → "Add Column" button visible in top-right toolbar
- Add a nullable column with no default → appears in list after confirm
- Add a NOT NULL column with a default → executes correctly
- Invalid type (e.g. `florp`) → error alert shown, no crash
- Right-click a column → "Drop Column…" appears below a divider after Rename/Edit
- Drop with Cancel → no change; Drop with confirm → column removed, tab refreshes
- Open a view → toolbar absent, context menu empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)