### PR TITLE
feat: drop and truncate table from sidebar (#121)

### DIFF
--- a/Tusk/Database/DatabaseClient.swift
+++ b/Tusk/Database/DatabaseClient.swift
@@ -170,6 +170,7 @@ actor DatabaseClient {
         let result = try await query("""
             SELECT
                 tc.constraint_name,
+                tc.table_schema AS from_schema,
                 tc.table_name   AS from_table,
                 kcu.column_name AS from_column,
                 ccu.column_name AS to_column
@@ -181,15 +182,16 @@ actor DatabaseClient {
             WHERE tc.constraint_type = 'FOREIGN KEY'
               AND ccu.table_schema = '\(s)'
               AND ccu.table_name   = '\(t)'
-            ORDER BY tc.table_name
+            ORDER BY tc.table_schema, tc.table_name
             """)
 
         return result.rows.map { row in
             IncomingReference(
                 constraintName: row[safe: 0]?.displayValue ?? "",
-                fromTable:      row[safe: 1]?.displayValue ?? "",
-                fromColumn:     row[safe: 2]?.displayValue ?? "",
-                toColumn:       row[safe: 3]?.displayValue ?? ""
+                fromSchema:     row[safe: 1]?.displayValue ?? "",
+                fromTable:      row[safe: 2]?.displayValue ?? "",
+                fromColumn:     row[safe: 3]?.displayValue ?? "",
+                toColumn:       row[safe: 4]?.displayValue ?? ""
             )
         }
     }

--- a/Tusk/Models/Connection.swift
+++ b/Tusk/Models/Connection.swift
@@ -104,6 +104,7 @@ struct ForeignKeyInfo: Identifiable, Sendable {
 struct IncomingReference: Identifiable, Sendable {
     var id: String { constraintName }
     let constraintName: String
+    let fromSchema: String  // schema that owns the FK table
     let fromTable: String   // the table that owns the FK
     let fromColumn: String  // the FK column in that table
     let toColumn: String    // the referenced column in the focal table

--- a/Tusk/Views/Sidebar/SidebarView.swift
+++ b/Tusk/Views/Sidebar/SidebarView.swift
@@ -411,6 +411,10 @@ private struct SchemaRow: View {
         Task {
             do {
                 _ = try await client.query(sql)
+                try? await appState.refreshSchema(for: connection)
+                if appState.schemaTableSizes[connection.id] != nil {
+                    await appState.loadTableSizes(for: connection)
+                }
             } catch {
                 let err = NSAlert()
                 err.messageText = "Truncate Failed"
@@ -427,7 +431,17 @@ private struct SchemaRow: View {
         guard let client = appState.clients[connection.id] else { return }
 
         Task {
-            let refs = (try? await client.incomingReferences(schema: table.schema, table: table.name)) ?? []
+            let refs: [IncomingReference]
+            do {
+                refs = try await client.incomingReferences(schema: table.schema, table: table.name)
+            } catch {
+                let err = NSAlert()
+                err.messageText = "Could Not Check Dependencies"
+                err.informativeText = error.localizedDescription
+                err.alertStyle = .warning
+                err.runModal()
+                return
+            }
 
             let alert = NSAlert()
             alert.messageText = "Drop Table \"\(table.name)\"?"
@@ -440,7 +454,7 @@ private struct SchemaRow: View {
                 alert.addButton(withTitle: "Cancel")
             } else {
                 hasDependents = true
-                let tableList = Array(Set(refs.map { $0.fromTable })).sorted().joined(separator: ", ")
+                let tableList = Array(Set(refs.map { "\($0.fromSchema).\($0.fromTable)" })).sorted().joined(separator: ", ")
                 alert.informativeText = "Table \"\(table.name)\" is referenced by foreign keys in: \(tableList).\n\n\"Drop Table\" will fail unless those constraints are removed first. \"Drop with CASCADE\" also drops all dependent objects — use with care."
                 alert.addButton(withTitle: "Drop Table")
                 alert.addButton(withTitle: "Drop with CASCADE")


### PR DESCRIPTION
## Summary
- Adds "Truncate Table…" and "Drop Table…" to the table context menu in the schema sidebar
- Truncate shows a confirmation alert with an optional "Restart sequences (RESTART IDENTITY)" checkbox
- Drop fetches incoming FK references first; if dependents exist, lists them and offers "Drop with CASCADE"; on success closes open detail tabs and refreshes the schema tree

## Issues
Closes #121

## Test plan
- Right-click a table → context menu shows Rename…, (divider), Truncate Table…, Drop Table…
- Truncate → confirmation alert appears naming the table; Cancel = no change; confirm = rows removed
- Truncate with "Restart sequences" checked → executes with RESTART IDENTITY
- Drop a table with no FK dependents → simple alert; confirm → table gone, schema refreshes, open tab closes
- Drop a table that other tables reference → alert lists the dependent tables with "Drop with CASCADE" option; Cancel = no change; "Drop Table" = fails at Postgres level (expected); "Drop with CASCADE" = drops with dependents
- Error from Postgres (e.g. permission denied) → error alert shown, no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)