### PR TITLE
feat: paste postgresql:// URI to auto-fill New Connection form (#102)

### DIFF
--- a/Tusk/Views/Sidebar/AddConnectionSheet.swift
+++ b/Tusk/Views/Sidebar/AddConnectionSheet.swift
@@ -282,18 +282,19 @@ struct AddConnectionSheet: View {
               comps.scheme == "postgresql" || comps.scheme == "postgres"
         else { return nil }
 
-        let h  = comps.host ?? "localhost"
+        // Require an explicit, non-empty host — don't silently fall back to localhost
+        guard let h = comps.host, !h.isEmpty else { return nil }
         let p  = comps.port.map { String($0) } ?? "5432"
         // Path is "/dbname" — strip the leading slash
         let db = comps.path.hasPrefix("/") ? String(comps.path.dropFirst()) : comps.path
         let u  = comps.user ?? ""
         let pw = comps.password ?? ""
 
-        // sslmode query param: anything other than "disable" → useSSL = true
-        let sslmode = comps.queryItems?.first(where: { $0.name == "sslmode" })?.value ?? ""
+        // sslmode query param: anything other than "disable" (case-insensitive) → useSSL = true
+        let sslmode = (comps.queryItems?.first(where: { $0.name == "sslmode" })?.value ?? "").lowercased()
         let ssl = !sslmode.isEmpty && sslmode != "disable"
 
-        guard !h.isEmpty, !db.isEmpty else { return nil }
+        guard !db.isEmpty else { return nil }
         return ParsedURI(host: h, port: p, database: db, username: u, password: pw, useSSL: ssl)
     }
 


### PR DESCRIPTION
## Summary
- Adds a "Paste URI" button to the New Connection sheet header
- Parses `postgresql://` and `postgres://` URIs from the clipboard, filling host, port, database, username, password, and SSL fields automatically
- Shows an inline dismissable error banner if the clipboard is empty or the URI is invalid

## Issues
Closes #102

## Test plan
- Copy `postgresql://user:pass@host:5432/db` → click Paste URI → all fields fill correctly
- Try URI with `?sslmode=require` → SSL toggle turns on; `?sslmode=disable` → SSL stays off
- Try with no port in URI → defaults to 5432
- Empty clipboard → orange error banner "Clipboard is empty."
- Non-URI clipboard content → error banner with expected format hint
- Click × on error banner → banner dismisses
- Open Edit Connection sheet → "Paste URI" button is not shown