### PR TITLE
feat: superuser badge and live filter bar in sidebar

### DIFF
--- a/Tusk/AppState.swift
+++ b/Tusk/AppState.swift
@@ -150,12 +150,15 @@ final class AppState {
             queryTabs[idx].connectionName = connection.name
         }
 
-        try? await refreshSchema(for: connection)
+        // refreshSchema calls loadSuperuserStatus on its success path;
+        // call it here only as a fallback for when schema refresh fails.
+        if (try? await refreshSchema(for: connection)) == nil {
+            await loadSuperuserStatus(for: connection)
+        }
         if UserDefaults.standard.bool(forKey: "tusk.sidebar.showTableSizes") {
             await loadTableSizes(for: connection)
         }
         await loadDatabases(for: connection)
-        await loadSuperuserStatus(for: connection)
     }
 
     func disconnect(_ connection: Connection) {
@@ -320,11 +323,15 @@ final class AppState {
 
     func loadSuperuserStatus(for connection: Connection) async {
         guard let client = clients[connection.id] else { return }
-        let result = try? await client.query("SELECT rolsuper FROM pg_roles WHERE rolname = current_user")
-        if case .bool(true) = result?.rows.first?.first {
-            superuserConnections.insert(connection.id)
-        } else {
-            superuserConnections.remove(connection.id)
+        do {
+            let result = try await client.query("SELECT rolsuper FROM pg_roles WHERE rolname = current_user")
+            if case .bool(true) = result.rows.first?.first {
+                superuserConnections.insert(connection.id)
+            } else {
+                superuserConnections.remove(connection.id)
+            }
+        } catch {
+            // Leave existing badge state unchanged — a query failure is not evidence of non-superuser.
         }
     }
 
@@ -375,11 +382,12 @@ final class AppState {
         schemaTableSizes.removeValue(forKey: connectionID)
         schemaRefreshErrors.removeValue(forKey: connectionID)
 
-        try? await refreshSchema(for: connection)
+        if (try? await refreshSchema(for: connection)) == nil {
+            await loadSuperuserStatus(for: connection)
+        }
         if UserDefaults.standard.bool(forKey: "tusk.sidebar.showTableSizes") {
             await loadTableSizes(for: connection)
         }
-        await loadSuperuserStatus(for: connection)
     }
 
     func openQueryTab(for connection: Connection) {

--- a/Tusk/Views/Sidebar/SidebarView.swift
+++ b/Tusk/Views/Sidebar/SidebarView.swift
@@ -57,6 +57,9 @@ struct SidebarView: View {
             .onChange(of: appState.clients.count) { _, _ in
                 filterText = ""
             }
+            .onChange(of: appState.selectedConnectionID) { _, _ in
+                filterText = ""
+            }
 
             // Bottom — file explorer
             FileExplorerView()


### PR DESCRIPTION
## Summary
- Adds a live filter bar above the schema tree; typing narrows schemas/tables/views/enums/sequences/functions by name (case-insensitive). Schemas whose own name matches are also kept.
- Shows an orange crown badge next to the connection name when the authenticated role has the PostgreSQL superuser privilege.
- Superuser status is refreshed on connect, database switch, and schema refresh.

## Issues
Closes #133
Closes #134

## Test plan
- [ ] Type a table name in the filter bar — only matching tables (and their parent schemas) appear
- [ ] Type a schema name — the schema appears even if no objects inside it match
- [ ] Clear button (×) removes the filter text
- [ ] Connect as a superuser — crown badge appears next to the connection name
- [ ] Connect as a non-superuser — no crown badge
- [ ] While connected as superuser, click "Refresh Schema" — badge persists; if role is revoked externally, badge disappears after refresh
- [ ] Switch database — superuser status re-evaluated for the new database's role