### PR TITLE
feat: Google Cloud SQL connection type with cloud-sql-proxy

### DIFF
--- a/Tusk.xcodeproj/project.pbxproj
+++ b/Tusk.xcodeproj/project.pbxproj
@@ -20,6 +20,8 @@
 		51A6EB67E1B6BA69959B4E7D /* CreateTableSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2D7A2C8664E78D1A769D1C2 /* CreateTableSheet.swift */; };
 		5EC184771B4FC8EB6B55DF1A /* KeychainManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0031996A15573BA8334CAB25 /* KeychainManager.swift */; };
 		62DF484EC5D8D90758FED098 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAC605F0F401EDB2A7D1C6AA /* ContentView.swift */; };
+		6686682D9E52B79EBDD0A5A0 /* CloudSQLInstancePickerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27CA54BB707DD57462515F8E /* CloudSQLInstancePickerSheet.swift */; };
+		67ED1AC12198AD0918B02A03 /* CloudSQLProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94B3CB106A5350A8C72161B8 /* CloudSQLProxy.swift */; };
 		6E83A0905EA999292F8C7622 /* CreateIndexSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 857CD7B4230E8C84954D257F /* CreateIndexSheet.swift */; };
 		7DAB39642DDB974C9033D770 /* WelcomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F317DCA7625AA05FB8810169 /* WelcomeView.swift */; };
 		7F0899718F61DC90F640A3C7 /* ConnectionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1B1C7B5BED9E0D467D5CFED /* ConnectionStore.swift */; };
@@ -54,6 +56,7 @@
 		193CE42C808DDA972A10DACE /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		1F1C8E9BF3BF31794B0FF27A /* SettingsPopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsPopover.swift; sourceTree = "<group>"; };
 		1FF763FE618CB1AE4E595F53 /* Tusk.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Tusk.entitlements; sourceTree = "<group>"; };
+		27CA54BB707DD57462515F8E /* CloudSQLInstancePickerSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudSQLInstancePickerSheet.swift; sourceTree = "<group>"; };
 		37B4E572B48F16D9767046C1 /* AddConnectionSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddConnectionSheet.swift; sourceTree = "<group>"; };
 		54DB2C1EDCFE2EC1D9FC21ED /* QueryEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryEditorView.swift; sourceTree = "<group>"; };
 		615C3C512A905EBC9A2F5662 /* Tusk.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Tusk.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -65,6 +68,7 @@
 		7D55DC649CC6986737268922 /* RelationsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelationsView.swift; sourceTree = "<group>"; };
 		857CD7B4230E8C84954D257F /* CreateIndexSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateIndexSheet.swift; sourceTree = "<group>"; };
 		934FF1C0EBB58E15CCAFABEA /* DataBrowserView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataBrowserView.swift; sourceTree = "<group>"; };
+		94B3CB106A5350A8C72161B8 /* CloudSQLProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudSQLProxy.swift; sourceTree = "<group>"; };
 		94BE01E87D7E3C7BDDE1D73E /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		9EBD0E0FCEF86AA688735504 /* QueryResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryResult.swift; sourceTree = "<group>"; };
 		A053CF122F6C07ED2D8AB8D8 /* RoleDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoleDetailView.swift; sourceTree = "<group>"; };
@@ -124,6 +128,7 @@
 		0D7AFB5F0A0865F521CDB1B0 /* Database */ = {
 			isa = PBXGroup;
 			children = (
+				94B3CB106A5350A8C72161B8 /* CloudSQLProxy.swift */,
 				E1B1C7B5BED9E0D467D5CFED /* ConnectionStore.swift */,
 				BA3E61CFF0505201909FC54F /* DatabaseClient.swift */,
 				0031996A15573BA8334CAB25 /* KeychainManager.swift */,
@@ -240,6 +245,7 @@
 			isa = PBXGroup;
 			children = (
 				37B4E572B48F16D9767046C1 /* AddConnectionSheet.swift */,
+				27CA54BB707DD57462515F8E /* CloudSQLInstancePickerSheet.swift */,
 				009D995F865C1E2F42BA3F72 /* FileExplorerView.swift */,
 				09DE3A60259B635D1BA6AEE2 /* SidebarView.swift */,
 			);
@@ -323,6 +329,8 @@
 				19F8F1956AE3FBCCD1F774D4 /* AddConnectionSheet.swift in Sources */,
 				E089453CC03E346608C81935 /* AddConstraintSheet.swift in Sources */,
 				88CB8E03F6BAAA888B4887F2 /* AppState.swift in Sources */,
+				6686682D9E52B79EBDD0A5A0 /* CloudSQLInstancePickerSheet.swift in Sources */,
+				67ED1AC12198AD0918B02A03 /* CloudSQLProxy.swift in Sources */,
 				B3A1EC28832572F3CC389E9B /* Connection.swift in Sources */,
 				7F0899718F61DC90F640A3C7 /* ConnectionStore.swift in Sources */,
 				FB2DF2917401EB297E0173FA /* Constants.swift in Sources */,

--- a/Tusk/AppState.swift
+++ b/Tusk/AppState.swift
@@ -14,6 +14,10 @@ final class AppState {
     // MARK: - SSH tunnels (one per tunnelled connection)
     var tunnels: [UUID: SSHTunnel] = [:]
 
+    // MARK: - Cloud SQL proxies (one per Cloud SQL connection)
+    var cloudProxies: [UUID: CloudSQLProxy] = [:]
+    var proxyStatuses: [UUID: CloudSQLProxy.Status] = [:]
+
     // MARK: - Sidebar selection
     var selectedSidebarItem: SidebarItem? = nil
 
@@ -30,6 +34,8 @@ final class AppState {
     var schemaSequences:    [UUID: [SequenceInfo]]  = [:]
     var schemaFunctions:    [UUID: [FunctionInfo]]  = [:]
     var schemaRefreshErrors:[UUID: String]          = [:]
+    /// All non-system schema names for a connection, regardless of whether they contain objects.
+    var schemaNamesCache:   [UUID: [String]]        = [:]
     /// keyed by connectionID → "schema.table" → TableSizeInfo
     var schemaTableSizes:   [UUID: [String: TableSizeInfo]] = [:]
     /// keyed by connectionID → sorted list of database names on that server
@@ -111,10 +117,30 @@ final class AppState {
         // that table tabs backed by the existing client stay renderable during reconnect.
         var effectiveConnection = connection
         var newTunnel: SSHTunnel? = nil
+        var newProxy: CloudSQLProxy? = nil
 
-        // Start SSH tunnel if enabled; the tunnel exposes a local port that
-        // PostgresNIO will connect to instead of the real host/port.
-        if connection.sshEnabled {
+        if connection.connectionType == .cloudSQL {
+            // Cloud SQL: start the Auth Proxy and patch host/port to the local end.
+            proxyStatuses[connection.id] = .starting
+            let proxy = CloudSQLProxy()
+            do {
+                let localPort = try await proxy.start(
+                    instanceConnectionName: connection.cloudSQLInstanceConnectionName,
+                    useIAMAuth: connection.useADC
+                )
+                newProxy = proxy
+                proxyStatuses[connection.id] = .running
+                effectiveConnection.host               = "127.0.0.1"
+                effectiveConnection.port               = localPort
+                effectiveConnection.useSSL             = false
+                effectiveConnection.verifySSLCertificate = false
+            } catch {
+                proxyStatuses[connection.id] = .crashed(error.localizedDescription)
+                throw error
+            }
+        } else if connection.sshEnabled {
+            // Start SSH tunnel if enabled; the tunnel exposes a local port that
+            // PostgresNIO will connect to instead of the real host/port.
             let passphrase = KeychainManager.shared.sshPassphrase(for: connection.id)
             let tunnel = SSHTunnel()
             try await tunnel.start(connection: connection, passphrase: passphrase)
@@ -124,13 +150,23 @@ final class AppState {
             effectiveConnection.port = localPort
         }
 
-        let password = KeychainManager.shared.password(for: connection.id) ?? ""
+        let password: String
+        if connection.connectionType == .cloudSQL && connection.useADC {
+            password = try await Task.detached { try CloudSQLProxy.fetchADCToken() }.value
+        } else {
+            password = KeychainManager.shared.password(for: connection.id) ?? ""
+        }
+
         let newClient = DatabaseClient()
         do {
             try await newClient.connect(to: effectiveConnection, password: password)
         } catch {
             await newClient.disconnect()
             if let tunnel = newTunnel { await tunnel.stop() }
+            if let proxy = newProxy {
+                proxyStatuses[connection.id] = .crashed(error.localizedDescription)
+                await proxy.stop()
+            }
             throw error
         }
 
@@ -141,7 +177,11 @@ final class AppState {
         if let oldTunnel = tunnels.removeValue(forKey: connection.id) {
             await oldTunnel.stop()
         }
+        if let oldProxy = cloudProxies.removeValue(forKey: connection.id) {
+            await oldProxy.stop()
+        }
         if let tunnel = newTunnel { tunnels[connection.id] = tunnel }
+        if let proxy = newProxy { cloudProxies[connection.id] = proxy }
         clients[connection.id] = newClient
         activeDatabase[connection.id] = connection.database
         selectedConnectionID = connection.id
@@ -166,14 +206,18 @@ final class AppState {
     func disconnect(_ connection: Connection) {
         let client = clients.removeValue(forKey: connection.id)
         let tunnel = tunnels.removeValue(forKey: connection.id)
+        let proxy  = cloudProxies.removeValue(forKey: connection.id)
+        proxyStatuses.removeValue(forKey: connection.id)
         Task {
             await client?.disconnect()
             await tunnel?.stop()
+            await proxy?.stop()
         }
         schemaTables.removeValue(forKey: connection.id)
         schemaEnums.removeValue(forKey: connection.id)
         schemaSequences.removeValue(forKey: connection.id)
         schemaFunctions.removeValue(forKey: connection.id)
+        schemaNamesCache.removeValue(forKey: connection.id)
         schemaRefreshErrors.removeValue(forKey: connection.id)
         schemaTableSizes.removeValue(forKey: connection.id)
         schemaDatabases.removeValue(forKey: connection.id)
@@ -206,6 +250,12 @@ final class AppState {
         clients[connection.id] != nil
     }
 
+    func restartProxy(for connection: Connection) async throws {
+        guard connection.connectionType == .cloudSQL else { return }
+        // Full reconnect rebuilds both the proxy and the Postgres client.
+        try await connect(connection)
+    }
+
     // MARK: - Schema refresh
 
     func refreshSchema(for connection: Connection) async throws {
@@ -215,15 +265,18 @@ final class AppState {
             async let enums     = try client.enums()
             async let sequences = try client.sequences()
             async let functions = try client.functions()
+            async let names     = try client.schemaNames()
             // Collect all results before writing — all-or-nothing to avoid partial cache state
             let t = try await tables
             let e = try await enums
             let s = try await sequences
             let f = try await functions
+            let n = try await names
             schemaTables[connection.id]    = t
             schemaEnums[connection.id]     = e
             schemaSequences[connection.id] = s
             schemaFunctions[connection.id] = f
+            schemaNamesCache[connection.id] = n
             schemaRefreshErrors.removeValue(forKey: connection.id)
             await loadSuperuserStatus(for: connection)
         } catch {
@@ -397,14 +450,25 @@ final class AppState {
         var effectiveConnection = connection
         effectiveConnection.database = database
 
-        // Reuse the existing SSH tunnel if present
+        // Reuse the existing SSH tunnel or Cloud SQL proxy if present
         if let tunnel = tunnels[connectionID] {
             let localPort = await tunnel.localPort
             effectiveConnection.host = "127.0.0.1"
             effectiveConnection.port = localPort
+        } else if let proxy = cloudProxies[connectionID] {
+            let localPort = await proxy.localPort
+            effectiveConnection.host               = "127.0.0.1"
+            effectiveConnection.port               = localPort
+            effectiveConnection.useSSL             = true
+            effectiveConnection.verifySSLCertificate = false
         }
 
-        let password = KeychainManager.shared.password(for: connectionID) ?? ""
+        let password: String
+        if connection.connectionType == .cloudSQL && connection.useADC {
+            password = try await Task.detached { try CloudSQLProxy.fetchADCToken() }.value
+        } else {
+            password = KeychainManager.shared.password(for: connectionID) ?? ""
+        }
         let newClient = DatabaseClient()
         do {
             try await newClient.connect(to: effectiveConnection, password: password)
@@ -432,6 +496,7 @@ final class AppState {
         schemaEnums.removeValue(forKey: connectionID)
         schemaSequences.removeValue(forKey: connectionID)
         schemaFunctions.removeValue(forKey: connectionID)
+        schemaNamesCache.removeValue(forKey: connectionID)
         schemaTableSizes.removeValue(forKey: connectionID)
         schemaRefreshErrors.removeValue(forKey: connectionID)
 

--- a/Tusk/AppState.swift
+++ b/Tusk/AppState.swift
@@ -105,8 +105,10 @@ final class AppState {
 
     func connect(_ connection: Connection) async throws {
         // Prevent overlapping connect attempts for the same connection.
-        // A second call while one is already in flight is silently dropped.
-        guard !connectingIDs.contains(connection.id) else { return }
+        guard !connectingIDs.contains(connection.id) else {
+            throw NSError(domain: "Tusk", code: 0,
+                          userInfo: [NSLocalizedDescriptionKey: "Already connecting to \(connection.name). Please wait."])
+        }
         connectingIDs.insert(connection.id)
         defer { connectingIDs.remove(connection.id) }
 
@@ -456,10 +458,24 @@ final class AppState {
             effectiveConnection.host = "127.0.0.1"
             effectiveConnection.port = localPort
         } else if let proxy = cloudProxies[connectionID] {
-            let localPort = await proxy.localPort
-            effectiveConnection.host               = "127.0.0.1"
-            effectiveConnection.port               = localPort
-            effectiveConnection.useSSL             = true
+            // If the proxy has crashed, restart it before switching databases.
+            if case .crashed = await proxy.status {
+                let newProxy = CloudSQLProxy()
+                proxyStatuses[connectionID] = .starting
+                let localPort = try await newProxy.start(
+                    instanceConnectionName: connection.cloudSQLInstanceConnectionName,
+                    useIAMAuth: connection.useADC
+                )
+                cloudProxies[connectionID] = newProxy
+                proxyStatuses[connectionID] = .running
+                effectiveConnection.host = "127.0.0.1"
+                effectiveConnection.port = localPort
+            } else {
+                let localPort = await proxy.localPort
+                effectiveConnection.host = "127.0.0.1"
+                effectiveConnection.port = localPort
+            }
+            effectiveConnection.useSSL             = false
             effectiveConnection.verifySSLCertificate = false
         }
 

--- a/Tusk/AppState.swift
+++ b/Tusk/AppState.swift
@@ -136,6 +136,12 @@ final class AppState {
                 effectiveConnection.port               = localPort
                 effectiveConnection.useSSL             = false
                 effectiveConnection.verifySSLCertificate = false
+                // Monitor the proxy for unexpected termination and sync status into
+                // proxyStatuses so the sidebar badge and Restart Proxy menu stay accurate.
+                let connectionID = connection.id
+                Task { [weak self] in
+                    await self?.monitorProxy(proxy, connectionID: connectionID)
+                }
             } catch {
                 proxyStatuses[connection.id] = .crashed(error.localizedDescription)
                 throw error
@@ -256,6 +262,27 @@ final class AppState {
         guard connection.connectionType == .cloudSQL else { return }
         // Full reconnect rebuilds both the proxy and the Postgres client.
         try await connect(connection)
+    }
+
+    /// Polls a running proxy until it crashes, then syncs the crash status into
+    /// proxyStatuses so the sidebar badge and "Restart Proxy" menu reflect reality.
+    private func monitorProxy(_ proxy: CloudSQLProxy, connectionID: UUID) async {
+        while true {
+            try? await Task.sleep(nanoseconds: 1_000_000_000) // 1 s
+            let current = await proxy.status
+            // If the proxy is still alive or we've already recorded a crash, stop.
+            guard case .running = current else {
+                if case .crashed(let msg) = current {
+                    // Only update if we still own this proxy (user may have reconnected).
+                    if cloudProxies[connectionID] === proxy {
+                        proxyStatuses[connectionID] = .crashed(msg)
+                    }
+                }
+                return
+            }
+            // Keep monitoring while the proxy's own status says it's still running.
+            if cloudProxies[connectionID] !== proxy { return }
+        }
     }
 
     // MARK: - Schema refresh
@@ -460,6 +487,7 @@ final class AppState {
         } else if let proxy = cloudProxies[connectionID] {
             // If the proxy has crashed, restart it before switching databases.
             if case .crashed = await proxy.status {
+                await proxy.stop()  // clean up pipe handlers / FDs before replacing
                 let newProxy = CloudSQLProxy()
                 proxyStatuses[connectionID] = .starting
                 let localPort = try await newProxy.start(
@@ -468,6 +496,7 @@ final class AppState {
                 )
                 cloudProxies[connectionID] = newProxy
                 proxyStatuses[connectionID] = .running
+                Task { [weak self] in await self?.monitorProxy(newProxy, connectionID: connectionID) }
                 effectiveConnection.host = "127.0.0.1"
                 effectiveConnection.port = localPort
             } else {

--- a/Tusk/Database/CloudSQLProxy.swift
+++ b/Tusk/Database/CloudSQLProxy.swift
@@ -60,10 +60,14 @@ actor CloudSQLProxy {
         do {
             try await waitForPort(port, timeout: 15)
         } catch {
+            // Clear the handler before reading so it doesn't race with availableData.
+            stderrPipe.fileHandleForReading.readabilityHandler = nil
             proc.terminate()
             process = nil
+            // Use availableData (non-blocking) instead of readDataToEndOfFile() which
+            // blocks until EOF and can hang if the process is slow to exit.
             let stderrOutput = String(
-                data: stderrPipe.fileHandleForReading.readDataToEndOfFile(),
+                data: stderrPipe.fileHandleForReading.availableData,
                 encoding: .utf8
             )?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
             let detail = stderrOutput.isEmpty ? error.localizedDescription : stderrOutput

--- a/Tusk/Database/CloudSQLProxy.swift
+++ b/Tusk/Database/CloudSQLProxy.swift
@@ -1,0 +1,242 @@
+import Foundation
+import Darwin
+
+// MARK: - CloudSQLProxy
+
+/// Manages a `cloud-sql-proxy` child process that forwards a Cloud SQL instance
+/// to a local TCP port. Mirrors the structure of SSHTunnel.
+actor CloudSQLProxy {
+    enum Status: Sendable {
+        case starting
+        case running
+        case crashed(String)
+    }
+
+    private(set) var status: Status = .starting
+    private(set) var localPort: Int = 0
+    /// Last 50 lines of proxy stderr — ring buffer for debugging.
+    private(set) var logLines: [String] = []
+
+    private var process: Process?
+
+    // MARK: - Start
+
+    func start(instanceConnectionName: String, useIAMAuth: Bool) async throws -> Int {
+        let port = try Self.findFreePort()
+        localPort = port
+
+        guard let binary = Self.findBinary("cloud-sql-proxy") else {
+            throw CloudSQLProxyError.binaryNotFound
+        }
+
+        var args = [instanceConnectionName, "--port", "\(port)"]
+        if useIAMAuth { args.append("--auto-iam-authn") }
+
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: binary)
+        proc.arguments = args
+        proc.standardOutput = FileHandle.nullDevice
+
+        let stderrPipe = Pipe()
+        proc.standardError = stderrPipe
+
+        // Capture stderr lines into the ring buffer.
+        stderrPipe.fileHandleForReading.readabilityHandler = { [weak self] handle in
+            let data = handle.availableData
+            guard !data.isEmpty, let text = String(data: data, encoding: .utf8) else { return }
+            let lines = text.components(separatedBy: .newlines).filter { !$0.isEmpty }
+            Task { await self?.appendLines(lines) }
+        }
+
+        // Detect unexpected exits while connected.
+        proc.terminationHandler = { [weak self] _ in
+            Task { await self?.handleTermination() }
+        }
+
+        try proc.run()
+        process = proc
+
+        // Poll until the proxy port accepts connections.
+        do {
+            try await waitForPort(port, timeout: 15)
+        } catch {
+            proc.terminate()
+            process = nil
+            let stderrOutput = String(
+                data: stderrPipe.fileHandleForReading.readDataToEndOfFile(),
+                encoding: .utf8
+            )?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            let detail = stderrOutput.isEmpty ? error.localizedDescription : stderrOutput
+            throw CloudSQLProxyError.proxyFailed(detail)
+        }
+
+        status = .running
+        return port
+    }
+
+    // MARK: - Stop
+
+    func stop() {
+        process?.standardError.flatMap { $0 as? Pipe }?.fileHandleForReading.readabilityHandler = nil
+        process?.terminate()
+        process = nil
+    }
+
+    // MARK: - Restart
+
+    func restart(instanceConnectionName: String, useIAMAuth: Bool) async throws -> Int {
+        stop()
+        status = .starting
+        logLines = []
+        return try await start(instanceConnectionName: instanceConnectionName, useIAMAuth: useIAMAuth)
+    }
+
+    // MARK: - Private
+
+    private func appendLines(_ lines: [String]) {
+        logLines.append(contentsOf: lines)
+        if logLines.count > 50 { logLines.removeFirst(logLines.count - 50) }
+    }
+
+    private func handleTermination() {
+        guard case .running = status else { return }
+        let lastLog = logLines.last ?? "Proxy exited unexpectedly."
+        status = .crashed(lastLog)
+    }
+
+    private func waitForPort(_ port: Int, timeout: TimeInterval) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if Self.isPortOpen(port) { return }
+            if let p = process, !p.isRunning {
+                throw CloudSQLProxyError.proxyFailed("cloud-sql-proxy exited (code \(p.terminationStatus))")
+            }
+            try await Task.sleep(nanoseconds: 200_000_000) // 200 ms
+        }
+        throw CloudSQLProxyError.timeout
+    }
+
+    // MARK: - Static helpers
+
+    static func isPortOpen(_ port: Int) -> Bool {
+        var addr        = sockaddr_in()
+        addr.sin_family = sa_family_t(AF_INET)
+        addr.sin_port   = in_port_t(port).bigEndian
+        addr.sin_addr   = in_addr(s_addr: inet_addr("127.0.0.1"))
+
+        let fd = socket(AF_INET, SOCK_STREAM, 0)
+        guard fd >= 0 else { return false }
+        defer { close(fd) }
+
+        return withUnsafePointer(to: &addr) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                connect(fd, $0, socklen_t(MemoryLayout<sockaddr_in>.size)) == 0
+            }
+        }
+    }
+
+    static func findFreePort() throws -> Int {
+        var addr           = sockaddr_in()
+        addr.sin_family    = sa_family_t(AF_INET)
+        addr.sin_port      = 0
+        addr.sin_addr      = in_addr(s_addr: INADDR_ANY)
+
+        let fd = socket(AF_INET, SOCK_STREAM, 0)
+        guard fd >= 0 else { throw CloudSQLProxyError.portUnavailable }
+        defer { close(fd) }
+
+        let bound = withUnsafeMutablePointer(to: &addr) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                bind(fd, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        guard bound == 0 else { throw CloudSQLProxyError.portUnavailable }
+
+        var filled = sockaddr_in()
+        var len    = socklen_t(MemoryLayout<sockaddr_in>.size)
+        _ = withUnsafeMutablePointer(to: &filled) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                getsockname(fd, $0, &len)
+            }
+        }
+        return Int(filled.sin_port.bigEndian)
+    }
+
+    /// Search common Homebrew / system locations then fall back to `which`.
+    static func findBinary(_ name: String) -> String? {
+        let candidates = [
+            "/usr/local/bin/\(name)",
+            "/opt/homebrew/bin/\(name)",
+            "/opt/homebrew/sbin/\(name)",
+            "/usr/bin/\(name)",
+        ]
+        if let hit = candidates.first(where: { FileManager.default.isExecutableFile(atPath: $0) }) {
+            return hit
+        }
+        // Last resort: ask the shell's PATH via `which`
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/usr/bin/which")
+        proc.arguments = [name]
+        let pipe = Pipe()
+        proc.standardOutput = pipe
+        proc.standardError  = FileHandle.nullDevice
+        try? proc.run()
+        proc.waitUntilExit()
+        let path = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return path.isEmpty ? nil : path
+    }
+
+    // MARK: - ADC token
+
+    /// Runs `gcloud auth print-access-token` synchronously and returns the token.
+    /// Call from a detached task to avoid blocking the main actor.
+    static func fetchADCToken() throws -> String {
+        guard let gcloud = findBinary("gcloud") else {
+            throw CloudSQLProxyError.gcloudNotFound
+        }
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: gcloud)
+        proc.arguments     = ["auth", "print-access-token"]
+        let pipe = Pipe()
+        proc.standardOutput = pipe
+        proc.standardError  = FileHandle.nullDevice
+        try proc.run()
+        proc.waitUntilExit()
+        guard proc.terminationStatus == 0 else {
+            throw CloudSQLProxyError.adcNotConfigured
+        }
+        let token = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !token.isEmpty else { throw CloudSQLProxyError.adcNotConfigured }
+        return token
+    }
+}
+
+// MARK: - CloudSQLProxyError
+
+enum CloudSQLProxyError: LocalizedError {
+    case binaryNotFound
+    case portUnavailable
+    case timeout
+    case proxyFailed(String)
+    case gcloudNotFound
+    case adcNotConfigured
+
+    var errorDescription: String? {
+        switch self {
+        case .binaryNotFound:
+            return "cloud-sql-proxy not found. Install it with: brew install cloud-sql-proxy"
+        case .portUnavailable:
+            return "Could not allocate a free local port for the Cloud SQL proxy."
+        case .timeout:
+            return "cloud-sql-proxy did not become ready within 15 seconds. Check the instance connection name and your GCP credentials."
+        case .proxyFailed(let detail):
+            return "cloud-sql-proxy failed to start: \(detail)"
+        case .gcloudNotFound:
+            return "gcloud not found. Install Google Cloud SDK from cloud.google.com/sdk."
+        case .adcNotConfigured:
+            return "Application Default Credentials not configured. Run: gcloud auth application-default login"
+        }
+    }
+}

--- a/Tusk/Database/DatabaseClient.swift
+++ b/Tusk/Database/DatabaseClient.swift
@@ -543,6 +543,20 @@ actor DatabaseClient {
         }
     }
 
+    // MARK: - Schema names (for showing empty schemas in the sidebar)
+
+    func schemaNames() async throws -> [String] {
+        let result = try await query("""
+            SELECT nspname
+            FROM pg_namespace
+            WHERE nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast')
+              AND nspname NOT LIKE 'pg_temp_%'
+              AND nspname NOT LIKE 'pg_toast_temp_%'
+            ORDER BY nspname
+            """)
+        return result.rows.compactMap { $0[safe: 0]?.displayValue }
+    }
+
     // MARK: - Databases
 
     func databases() async throws -> [String] {

--- a/Tusk/Models/Connection.swift
+++ b/Tusk/Models/Connection.swift
@@ -1,6 +1,13 @@
 import Foundation
 import SwiftUI
 
+// MARK: - ConnectionType
+
+enum ConnectionType: String, Codable, CaseIterable, Sendable {
+    case direct
+    case cloudSQL
+}
+
 // MARK: - Connection
 
 struct Connection: Identifiable, Codable, Hashable, Sendable {
@@ -24,9 +31,17 @@ struct Connection: Identifiable, Codable, Hashable, Sendable {
     var sshUser: String = ""
     var sshKeyPath: String = ""
 
+    // Google Cloud SQL
+    var connectionType: ConnectionType = .direct
+    var cloudSQLInstanceConnectionName: String = ""
+    var cloudSQLProject: String = ""   // display only (e.g. "my-project")
+    var useADC: Bool = false           // use Application Default Credentials instead of a password
+
     // Password is NOT stored here — lives in Keychain only.
 
-    var displayHost: String { "\(host):\(port)" }
+    var displayHost: String {
+        connectionType == .cloudSQL ? cloudSQLInstanceConnectionName : "\(host):\(port)"
+    }
 }
 
 extension Connection {
@@ -52,6 +67,10 @@ extension Connection {
         sshPort     = try c.decodeIfPresent(Int.self,     forKey: .sshPort)     ?? 22
         sshUser     = try c.decodeIfPresent(String.self,  forKey: .sshUser)     ?? ""
         sshKeyPath  = try c.decodeIfPresent(String.self,  forKey: .sshKeyPath)  ?? ""
+        connectionType                 = try c.decodeIfPresent(ConnectionType.self, forKey: .connectionType)                 ?? .direct
+        cloudSQLInstanceConnectionName = try c.decodeIfPresent(String.self,         forKey: .cloudSQLInstanceConnectionName) ?? ""
+        cloudSQLProject                = try c.decodeIfPresent(String.self,         forKey: .cloudSQLProject)                ?? ""
+        useADC                         = try c.decodeIfPresent(Bool.self,           forKey: .useADC)                         ?? false
     }
 }
 

--- a/Tusk/Views/Sidebar/AddConnectionSheet.swift
+++ b/Tusk/Views/Sidebar/AddConnectionSheet.swift
@@ -8,6 +8,9 @@ struct AddConnectionSheet: View {
     // nil = new connection, non-nil = editing existing
     let connection: Connection?
 
+    @State private var connectionType: ConnectionType = .direct
+
+    // Direct TCP fields
     @State private var name: String = ""
     @State private var notes: String = ""
     @State private var host: String = "localhost"
@@ -27,11 +30,29 @@ struct AddConnectionSheet: View {
     @State private var sshKeyPath: String = ""
     @State private var sshPassphrase: String = ""
 
+    // Cloud SQL fields
+    @State private var cloudSQLInstanceConnectionName: String = ""
+    @State private var cloudSQLProject: String = ""
+    @State private var useADC: Bool = false
+    @State private var showingInstancePicker = false
+    @State private var availableDatabases: [String] = []
+    @State private var isLoadingDatabases = false
+    @State private var showingDatabasePopover = false
+
     @State private var isTestingConnection = false
     @State private var testResult: String? = nil
     @State private var uriError: String? = nil
 
     var isEditing: Bool { connection != nil }
+
+    private var isCloudSQL: Bool { connectionType == .cloudSQL }
+
+    private var saveDisabled: Bool {
+        if isCloudSQL {
+            return name.isEmpty || cloudSQLInstanceConnectionName.isEmpty || database.isEmpty || username.isEmpty
+        }
+        return name.isEmpty || host.isEmpty || database.isEmpty || username.isEmpty
+    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -40,7 +61,7 @@ struct AddConnectionSheet: View {
                 Text(isEditing ? "Edit Connection" : "New Connection")
                     .font(.headline)
                 Spacer()
-                if !isEditing {
+                if !isEditing && !isCloudSQL {
                     Button("Paste URI") { pasteURI() }
                         .help("Parse a postgresql:// URI from the clipboard and fill in the fields below")
                 }
@@ -48,7 +69,7 @@ struct AddConnectionSheet: View {
                     .keyboardShortcut(.cancelAction)
                 Button(isEditing ? "Save" : "Add") { save() }
                     .keyboardShortcut(.defaultAction)
-                    .disabled(name.isEmpty || host.isEmpty || database.isEmpty || username.isEmpty)
+                    .disabled(saveDisabled)
             }
             .padding()
 
@@ -111,48 +132,124 @@ struct AddConnectionSheet: View {
                     }
                     TextField("Notes (optional)", text: $notes)
                         .foregroundStyle(notes.isEmpty ? .secondary : .primary)
-                }
 
-                Section("Server") {
-                    HStack {
-                        TextField("Host", text: $host)
-                        TextField("Port", text: $port)
-                            .frame(width: 70)
+                    Picker("Type", selection: $connectionType) {
+                        Text("Direct TCP").tag(ConnectionType.direct)
+                        Text("Google Cloud SQL").tag(ConnectionType.cloudSQL)
                     }
-                    TextField("Database", text: $database)
+                    .pickerStyle(.menu)
                 }
 
-                Section("Authentication") {
-                    TextField("Username", text: $username)
-                    SecureField("Password", text: $password)
-                    Toggle("Use SSL", isOn: $useSSL)
-                    if useSSL {
-                        Toggle("Verify Certificate", isOn: $verifySSLCertificate)
-                            .padding(.leading, 16)
-                    }
-                    Toggle("Read-only", isOn: $isReadOnly)
-                }
-
-                Section("SSH Tunnel") {
-                    Toggle("Use SSH Tunnel", isOn: $sshEnabled)
-
-                    if sshEnabled {
+                if isCloudSQL {
+                    // Cloud SQL section
+                    Section("Google Cloud SQL") {
                         HStack {
-                            TextField("Host", text: $sshHost)
-                            TextField("Port", text: $sshPort)
+                            TextField("Instance connection name (project:region:instance)",
+                                      text: $cloudSQLInstanceConnectionName)
+                            Button("Browse…") { showingInstancePicker = true }
+                                .buttonStyle(.borderless)
+                                .disabled(CloudSQLProxy.findBinary("gcloud") == nil)
+                                .help(CloudSQLProxy.findBinary("gcloud") == nil
+                                      ? "gcloud not found. Install Google Cloud SDK."
+                                      : "Browse Cloud SQL instances from gcloud")
+                        }
+                        HStack {
+                            TextField("Database", text: $database)
+                            if isLoadingDatabases {
+                                ProgressView().controlSize(.small)
+                            } else {
+                                Button("Browse…") {
+                                    Task { await fetchDatabases() }
+                                }
+                                .buttonStyle(.borderless)
+                                .disabled(cloudSQLInstanceConnectionName.isEmpty
+                                          || CloudSQLProxy.findBinary("gcloud") == nil)
+                                .help(cloudSQLInstanceConnectionName.isEmpty
+                                      ? "Select an instance first"
+                                      : "List databases on this instance")
+                                .popover(isPresented: $showingDatabasePopover, arrowEdge: .trailing) {
+                                    DatabasePickerPopover(
+                                        databases: availableDatabases,
+                                        onSelect: { database = $0; showingDatabasePopover = false }
+                                    )
+                                }
+                            }
+                        }
+                    }
+
+                    Section("Authentication") {
+                        TextField("Username", text: $username)
+                        Toggle("Use Application Default Credentials", isOn: $useADC)
+                        if !useADC {
+                            SecureField("Password", text: $password)
+                        } else {
+                            Text("Token will be fetched via `gcloud auth print-access-token` at connect time.")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                        Toggle("Read-only", isOn: $isReadOnly)
+                    }
+
+                    Section {
+                        HStack(spacing: 6) {
+                            Image(systemName: "lock.shield.fill")
+                                .foregroundStyle(.green)
+                            Text("cloud-sql-proxy encrypts traffic to Cloud SQL. The local connection to the proxy uses plain TCP.")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+
+                } else {
+                    // Direct TCP sections
+                    Section("Server") {
+                        HStack {
+                            TextField("Host", text: $host)
+                            TextField("Port", text: $port)
                                 .frame(width: 70)
                         }
-                        TextField("User", text: $sshUser)
-                        HStack {
-                            TextField("Key Path", text: $sshKeyPath)
-                            Button("Browse…") { pickKey() }
-                                .buttonStyle(.borderless)
+                        TextField("Database", text: $database)
+                    }
+
+                    Section("Authentication") {
+                        TextField("Username", text: $username)
+                        SecureField("Password", text: $password)
+                        Toggle("Use SSL", isOn: $useSSL)
+                        if useSSL {
+                            Toggle("Verify Certificate", isOn: $verifySSLCertificate)
+                                .padding(.leading, 16)
                         }
-                        SecureField("Passphrase", text: $sshPassphrase)
+                        Toggle("Read-only", isOn: $isReadOnly)
+                    }
+
+                    Section("SSH Tunnel") {
+                        Toggle("Use SSH Tunnel", isOn: $sshEnabled)
+
+                        if sshEnabled {
+                            HStack {
+                                TextField("Host", text: $sshHost)
+                                TextField("Port", text: $sshPort)
+                                    .frame(width: 70)
+                            }
+                            TextField("User", text: $sshUser)
+                            HStack {
+                                TextField("Key Path", text: $sshKeyPath)
+                                Button("Browse…") { pickKey() }
+                                    .buttonStyle(.borderless)
+                            }
+                            SecureField("Passphrase", text: $sshPassphrase)
+                        }
                     }
                 }
             }
             .formStyle(.grouped)
+            .sheet(isPresented: $showingInstancePicker) {
+                CloudSQLInstancePickerSheet { instance in
+                    cloudSQLInstanceConnectionName = instance.connectionName
+                    cloudSQLProject = instance.project
+                    if name.isEmpty { name = instance.name }
+                }
+            }
 
             Divider()
 
@@ -168,7 +265,10 @@ struct AddConnectionSheet: View {
                             Text("Test Connection")
                         }
                     }
-                    .disabled(host.isEmpty || database.isEmpty || username.isEmpty)
+                    .disabled({
+                        if isCloudSQL { return cloudSQLInstanceConnectionName.isEmpty || database.isEmpty || username.isEmpty }
+                        return host.isEmpty || database.isEmpty || username.isEmpty
+                    }())
 
                     Spacer()
                 }
@@ -182,7 +282,7 @@ struct AddConnectionSheet: View {
             }
             .padding()
         }
-        .frame(width: 460)
+        .frame(width: 480)
         .onAppear { populate() }
     }
 
@@ -190,23 +290,27 @@ struct AddConnectionSheet: View {
 
     private func populate() {
         guard let c = connection else { return }
-        name          = c.name
-        host          = c.host
-        port          = String(c.port)
-        database      = c.database
-        username      = c.username
-        password      = KeychainManager.shared.password(for: c.id) ?? ""
+        connectionType  = c.connectionType
+        name            = c.name
+        host            = c.host
+        port            = String(c.port)
+        database        = c.database
+        username        = c.username
+        password        = KeychainManager.shared.password(for: c.id) ?? ""
         useSSL                = c.useSSL
         verifySSLCertificate  = c.verifySSLCertificate
         isReadOnly            = c.isReadOnly
-        color         = c.color
-        sshEnabled    = c.sshEnabled
-        sshHost       = c.sshHost
-        sshPort       = String(c.sshPort)
-        sshUser       = c.sshUser
-        sshKeyPath    = c.sshKeyPath
-        sshPassphrase = KeychainManager.shared.sshPassphrase(for: c.id) ?? ""
-        notes         = c.notes
+        color           = c.color
+        sshEnabled      = c.sshEnabled
+        sshHost         = c.sshHost
+        sshPort         = String(c.sshPort)
+        sshUser         = c.sshUser
+        sshKeyPath      = c.sshKeyPath
+        sshPassphrase   = KeychainManager.shared.sshPassphrase(for: c.id) ?? ""
+        notes           = c.notes
+        cloudSQLInstanceConnectionName = c.cloudSQLInstanceConnectionName
+        cloudSQLProject = c.cloudSQLProject
+        useADC          = c.useADC
     }
 
     private func pickKey() {
@@ -227,6 +331,7 @@ struct AddConnectionSheet: View {
         let sshPortInt = Int(sshPort) ?? 22
         if let existing = connection {
             var updated          = existing
+            updated.connectionType = connectionType
             updated.name         = name
             updated.host         = host
             updated.port         = portInt
@@ -242,22 +347,29 @@ struct AddConnectionSheet: View {
             updated.sshUser      = sshUser
             updated.sshKeyPath   = sshKeyPath
             updated.notes        = notes
+            updated.cloudSQLInstanceConnectionName = cloudSQLInstanceConnectionName
+            updated.cloudSQLProject = cloudSQLProject
+            updated.useADC       = useADC
             KeychainManager.shared.setPassword(password, for: updated.id)
             KeychainManager.shared.setSshPassphrase(sshPassphrase, for: updated.id)
             appState.updateConnection(updated)
         } else {
-            var new          = Connection(
+            var new = Connection(
                 name: name, host: host, port: portInt,
                 database: database, username: username,
                 useSSL: useSSL, verifySSLCertificate: verifySSLCertificate,
                 isReadOnly: isReadOnly, color: color
             )
-            new.sshEnabled   = sshEnabled
-            new.sshHost      = sshHost
-            new.sshPort      = sshPortInt
-            new.notes        = notes
-            new.sshUser      = sshUser
-            new.sshKeyPath   = sshKeyPath
+            new.connectionType = connectionType
+            new.sshEnabled  = sshEnabled
+            new.sshHost     = sshHost
+            new.sshPort     = sshPortInt
+            new.notes       = notes
+            new.sshUser     = sshUser
+            new.sshKeyPath  = sshKeyPath
+            new.cloudSQLInstanceConnectionName = cloudSQLInstanceConnectionName
+            new.cloudSQLProject = cloudSQLProject
+            new.useADC      = useADC
             KeychainManager.shared.setPassword(password, for: new.id)
             KeychainManager.shared.setSshPassphrase(sshPassphrase, for: new.id)
             appState.addConnection(new)
@@ -326,7 +438,17 @@ struct AddConnectionSheet: View {
         isTestingConnection = true
         testResult = nil
 
-        var info        = Connection(
+        if isCloudSQL {
+            await testCloudSQLConnection()
+        } else {
+            await testDirectConnection()
+        }
+
+        isTestingConnection = false
+    }
+
+    private func testDirectConnection() async {
+        var info = Connection(
             name: name, host: host, port: Int(port) ?? 5432,
             database: database, username: username,
             useSSL: useSSL, verifySSLCertificate: verifySSLCertificate, isReadOnly: isReadOnly
@@ -340,7 +462,6 @@ struct AddConnectionSheet: View {
         var tunnel: SSHTunnel? = nil
 
         do {
-            // Start SSH tunnel if enabled and patch host/port to the local end.
             if sshEnabled {
                 let t = SSHTunnel()
                 try await t.start(
@@ -365,7 +486,122 @@ struct AddConnectionSheet: View {
         }
 
         if let tunnel { await tunnel.stop() }
-        isTestingConnection = false
+    }
+
+    private func fetchDatabases() async {
+        isLoadingDatabases = true
+        availableDatabases = []
+        defer { isLoadingDatabases = false }
+
+        // Parse project:region:instance — project is the first component.
+        let parts = cloudSQLInstanceConnectionName.split(separator: ":").map(String.init)
+        let instanceName = parts.last ?? cloudSQLInstanceConnectionName
+        let project = parts.first ?? cloudSQLProject
+
+        guard let gcloud = CloudSQLProxy.findBinary("gcloud") else { return }
+
+        do {
+            let dbs = try await Task.detached {
+                let proc = Process()
+                proc.executableURL = URL(fileURLWithPath: gcloud)
+                var args = ["sql", "databases", "list",
+                            "--instance", instanceName,
+                            "--format=json"]
+                if !project.isEmpty { args += ["--project", project] }
+                proc.arguments = args
+                let pipe = Pipe()
+                proc.standardOutput = pipe
+                proc.standardError  = FileHandle.nullDevice
+                try proc.run()
+                proc.waitUntilExit()
+                guard proc.terminationStatus == 0 else { return [String]() }
+                let data = pipe.fileHandleForReading.readDataToEndOfFile()
+                guard let json = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] else {
+                    return [String]()
+                }
+                return json.compactMap { $0["name"] as? String }
+                           .filter { $0 != "information_schema" && $0 != "performance_schema" && $0 != "mysql" && $0 != "sys" }
+                           .sorted()
+            }.value
+            availableDatabases = dbs
+            if !dbs.isEmpty { showingDatabasePopover = true }
+        } catch {
+            // Silently fall through — user can still type the name manually.
+        }
+    }
+
+    private func testCloudSQLConnection() async {
+        let proxy = CloudSQLProxy()
+        var effectiveInfo = Connection(
+            name: name, host: "127.0.0.1", port: 5432,
+            database: database, username: username,
+            useSSL: false, verifySSLCertificate: false, isReadOnly: isReadOnly
+        )
+        do {
+            let localPort = try await proxy.start(
+                instanceConnectionName: cloudSQLInstanceConnectionName,
+                useIAMAuth: useADC
+            )
+            effectiveInfo.port = localPort
+
+            let pw: String
+            if useADC {
+                pw = try await Task.detached { try CloudSQLProxy.fetchADCToken() }.value
+            } else {
+                pw = password
+            }
+
+            let client = DatabaseClient()
+            do {
+                try await client.connect(to: effectiveInfo, password: pw)
+                await client.disconnect()
+                testResult = "✓ Connected successfully"
+            } catch {
+                testResult = "✗ \(friendlyError(error))"
+            }
+        } catch {
+            testResult = "✗ \(friendlyError(error))"
+        }
+        await proxy.stop()
+    }
+}
+
+// MARK: - Database picker popover
+
+private struct DatabasePickerPopover: View {
+    let databases: [String]
+    let onSelect: (String) -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Text("Choose Database")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 12)
+                .padding(.top, 10)
+                .padding(.bottom, 6)
+            Divider()
+            ScrollView {
+                VStack(spacing: 0) {
+                    ForEach(databases, id: \.self) { db in
+                        Button {
+                            onSelect(db)
+                        } label: {
+                            Text(db)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .padding(.horizontal, 12)
+                                .padding(.vertical, 6)
+                                .contentShape(Rectangle())
+                        }
+                        .buttonStyle(.plain)
+                        .background(Color.primary.opacity(0.001))
+                        Divider()
+                    }
+                }
+            }
+        }
+        .frame(width: 200)
+        .frame(maxHeight: 240)
     }
 }
 

--- a/Tusk/Views/Sidebar/AddConnectionSheet.swift
+++ b/Tusk/Views/Sidebar/AddConnectionSheet.swift
@@ -42,6 +42,7 @@ struct AddConnectionSheet: View {
     @State private var isTestingConnection = false
     @State private var testResult: String? = nil
     @State private var uriError: String? = nil
+    @State private var testProxy: CloudSQLProxy? = nil
 
     var isEditing: Bool { connection != nil }
 
@@ -284,6 +285,12 @@ struct AddConnectionSheet: View {
         }
         .frame(width: 480)
         .onAppear { populate() }
+        .onDisappear {
+            if let proxy = testProxy {
+                Task { await proxy.stop() }
+                testProxy = nil
+            }
+        }
     }
 
     // MARK: - Actions
@@ -327,6 +334,13 @@ struct AddConnectionSheet: View {
     }
 
     private func save() {
+        if isCloudSQL {
+            let parts = cloudSQLInstanceConnectionName.split(separator: ":")
+            guard parts.count == 3, parts.allSatisfy({ !$0.isEmpty }) else {
+                uriError = "Instance connection name must be in the format project:region:instance"
+                return
+            }
+        }
         let portInt    = Int(port) ?? 5432
         let sshPortInt = Int(sshPort) ?? 22
         if let existing = connection {
@@ -350,7 +364,7 @@ struct AddConnectionSheet: View {
             updated.cloudSQLInstanceConnectionName = cloudSQLInstanceConnectionName
             updated.cloudSQLProject = cloudSQLProject
             updated.useADC       = useADC
-            KeychainManager.shared.setPassword(password, for: updated.id)
+            if !useADC { KeychainManager.shared.setPassword(password, for: updated.id) }
             KeychainManager.shared.setSshPassphrase(sshPassphrase, for: updated.id)
             appState.updateConnection(updated)
         } else {
@@ -370,7 +384,7 @@ struct AddConnectionSheet: View {
             new.cloudSQLInstanceConnectionName = cloudSQLInstanceConnectionName
             new.cloudSQLProject = cloudSQLProject
             new.useADC      = useADC
-            KeychainManager.shared.setPassword(password, for: new.id)
+            if !useADC { KeychainManager.shared.setPassword(password, for: new.id) }
             KeychainManager.shared.setSshPassphrase(sshPassphrase, for: new.id)
             appState.addConnection(new)
         }
@@ -489,6 +503,7 @@ struct AddConnectionSheet: View {
     }
 
     private func fetchDatabases() async {
+        guard !isLoadingDatabases else { return }
         isLoadingDatabases = true
         availableDatabases = []
         defer { isLoadingDatabases = false }
@@ -532,6 +547,8 @@ struct AddConnectionSheet: View {
 
     private func testCloudSQLConnection() async {
         let proxy = CloudSQLProxy()
+        testProxy = proxy
+        defer { testProxy = nil }
         var effectiveInfo = Connection(
             name: name, host: "127.0.0.1", port: 5432,
             database: database, username: username,

--- a/Tusk/Views/Sidebar/AddConnectionSheet.swift
+++ b/Tusk/Views/Sidebar/AddConnectionSheet.swift
@@ -43,6 +43,7 @@ struct AddConnectionSheet: View {
     @State private var testResult: String? = nil
     @State private var uriError: String? = nil
     @State private var testProxy: CloudSQLProxy? = nil
+    @State private var gcloudAvailable: Bool = true
 
     var isEditing: Bool { connection != nil }
 
@@ -149,10 +150,10 @@ struct AddConnectionSheet: View {
                                       text: $cloudSQLInstanceConnectionName)
                             Button("Browse…") { showingInstancePicker = true }
                                 .buttonStyle(.borderless)
-                                .disabled(CloudSQLProxy.findBinary("gcloud") == nil)
-                                .help(CloudSQLProxy.findBinary("gcloud") == nil
-                                      ? "gcloud not found. Install Google Cloud SDK."
-                                      : "Browse Cloud SQL instances from gcloud")
+                                .disabled(!gcloudAvailable)
+                                .help(gcloudAvailable
+                                      ? "Browse Cloud SQL instances from gcloud"
+                                      : "gcloud not found. Install Google Cloud SDK.")
                         }
                         HStack {
                             TextField("Database", text: $database)
@@ -164,7 +165,7 @@ struct AddConnectionSheet: View {
                                 }
                                 .buttonStyle(.borderless)
                                 .disabled(cloudSQLInstanceConnectionName.isEmpty
-                                          || CloudSQLProxy.findBinary("gcloud") == nil)
+                                          || !gcloudAvailable)
                                 .help(cloudSQLInstanceConnectionName.isEmpty
                                       ? "Select an instance first"
                                       : "List databases on this instance")
@@ -284,7 +285,10 @@ struct AddConnectionSheet: View {
             .padding()
         }
         .frame(width: 480)
-        .onAppear { populate() }
+        .onAppear {
+            populate()
+            gcloudAvailable = CloudSQLProxy.findBinary("gcloud") != nil
+        }
         .onDisappear {
             if let proxy = testProxy {
                 Task { await proxy.stop() }
@@ -364,7 +368,11 @@ struct AddConnectionSheet: View {
             updated.cloudSQLInstanceConnectionName = cloudSQLInstanceConnectionName
             updated.cloudSQLProject = cloudSQLProject
             updated.useADC       = useADC
-            if !useADC { KeychainManager.shared.setPassword(password, for: updated.id) }
+            if useADC {
+                KeychainManager.shared.deletePassword(for: updated.id)
+            } else {
+                KeychainManager.shared.setPassword(password, for: updated.id)
+            }
             KeychainManager.shared.setSshPassphrase(sshPassphrase, for: updated.id)
             appState.updateConnection(updated)
         } else {
@@ -384,7 +392,11 @@ struct AddConnectionSheet: View {
             new.cloudSQLInstanceConnectionName = cloudSQLInstanceConnectionName
             new.cloudSQLProject = cloudSQLProject
             new.useADC      = useADC
-            if !useADC { KeychainManager.shared.setPassword(password, for: new.id) }
+            if useADC {
+                KeychainManager.shared.deletePassword(for: new.id)
+            } else {
+                KeychainManager.shared.setPassword(password, for: new.id)
+            }
             KeychainManager.shared.setSshPassphrase(sshPassphrase, for: new.id)
             appState.addConnection(new)
         }

--- a/Tusk/Views/Sidebar/CloudSQLInstancePickerSheet.swift
+++ b/Tusk/Views/Sidebar/CloudSQLInstancePickerSheet.swift
@@ -1,0 +1,219 @@
+import SwiftUI
+
+// MARK: - CloudSQLInstance model
+
+struct CloudSQLInstance: Identifiable, Hashable, Sendable {
+    var id: String { connectionName }
+    let connectionName: String   // project:region:instance
+    let project: String
+    let region: String
+    let name: String
+    let databaseVersion: String
+}
+
+// MARK: - CloudSQLInstancePickerSheet
+
+struct CloudSQLInstancePickerSheet: View {
+    /// Called with the chosen instance when the user taps Select.
+    let onSelect: @Sendable (CloudSQLInstance) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var instances: [CloudSQLInstance] = []
+    @State private var filterText = ""
+    @State private var selectedID: String? = nil   // matches CloudSQLInstance.id (connectionName)
+    @State private var isLoading = true
+    @State private var errorMessage: String? = nil
+
+    private var selectedInstance: CloudSQLInstance? {
+        guard let id = selectedID else { return nil }
+        return filtered.first(where: { $0.id == id }) ?? instances.first(where: { $0.id == id })
+    }
+
+    var filtered: [CloudSQLInstance] {
+        guard !filterText.isEmpty else { return instances }
+        let f = filterText.lowercased()
+        return instances.filter {
+            $0.name.lowercased().contains(f)     ||
+            $0.project.lowercased().contains(f)  ||
+            $0.region.lowercased().contains(f)
+        }
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Header
+            HStack {
+                Text("Browse Cloud SQL Instances")
+                    .font(.headline)
+                Spacer()
+                Button("Cancel") { dismiss() }
+                    .keyboardShortcut(.cancelAction)
+                Button("Select") {
+                    if let s = selectedInstance { onSelect(s); dismiss() }
+                }
+                .keyboardShortcut(.defaultAction)
+                .disabled(selectedInstance == nil)
+            }
+            .padding()
+
+            Divider()
+
+            if isLoading {
+                VStack(spacing: 12) {
+                    ProgressView()
+                    Text("Loading instances from gcloud…")
+                        .foregroundStyle(.secondary)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+            } else if let err = errorMessage {
+                VStack(spacing: 12) {
+                    Image(systemName: "exclamationmark.triangle")
+                        .font(.largeTitle)
+                        .foregroundStyle(.orange)
+                    Text(err)
+                        .multilineTextAlignment(.center)
+                        .foregroundStyle(.secondary)
+                    Button("Retry") { Task { await load() } }
+                }
+                .padding()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+            } else if instances.isEmpty {
+                Text("No Cloud SQL instances found in the active gcloud project.\nRun `gcloud config set project <project>` to switch projects.")
+                    .multilineTextAlignment(.center)
+                    .foregroundStyle(.secondary)
+                    .padding()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+            } else {
+                // Filter bar
+                HStack(spacing: 6) {
+                    Image(systemName: "magnifyingglass")
+                        .foregroundStyle(.tertiary)
+                    TextField("Filter…", text: $filterText)
+                        .textFieldStyle(.plain)
+                    if !filterText.isEmpty {
+                        Button {
+                            filterText = ""
+                        } label: {
+                            Image(systemName: "xmark.circle.fill")
+                                .foregroundStyle(.tertiary)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+                .background(.bar)
+
+                Divider()
+
+                List(filtered, selection: $selectedID) { instance in
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(instance.name)
+                            .font(.body)
+                        HStack(spacing: 6) {
+                            Text(instance.project)
+                            Text("·").foregroundStyle(.tertiary)
+                            Text(instance.region)
+                            Text("·").foregroundStyle(.tertiary)
+                            Text(instance.databaseVersion)
+                        }
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    }
+                    .padding(.vertical, 2)
+                }
+                .listStyle(.inset)
+                .onDoubleClick {
+                    if let s = selectedInstance { onSelect(s); dismiss() }
+                }
+            }
+        }
+        .frame(width: 480, height: 380)
+        .task { await load() }
+    }
+
+    // MARK: - Data loading
+
+    private func load() async {
+        isLoading = true
+        errorMessage = nil
+        do {
+            instances = try await fetchInstances()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+        isLoading = false
+    }
+
+    private func fetchInstances() async throws -> [CloudSQLInstance] {
+        try await Task.detached {
+            guard let gcloud = CloudSQLProxy.findBinary("gcloud") else {
+                throw CloudSQLProxyError.gcloudNotFound
+            }
+            let proc = Process()
+            proc.executableURL = URL(fileURLWithPath: gcloud)
+            proc.arguments     = ["sql", "instances", "list", "--format=json"]
+            let pipe = Pipe()
+            proc.standardOutput = pipe
+            proc.standardError  = FileHandle.nullDevice
+            try proc.run()
+            proc.waitUntilExit()
+            guard proc.terminationStatus == 0 else {
+                throw CloudSQLListError.commandFailed
+            }
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            return try Self.parseInstances(from: data)
+        }.value
+    }
+
+    private nonisolated static func parseInstances(from data: Data) throws -> [CloudSQLInstance] {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] else {
+            throw CloudSQLListError.parseError
+        }
+        return json.compactMap { item -> CloudSQLInstance? in
+            guard
+                let connectionName  = item["connectionName"] as? String,
+                let name            = item["name"] as? String,
+                let project         = item["project"] as? String,
+                let region          = item["region"] as? String,
+                let dbVersion       = item["databaseVersion"] as? String
+            else { return nil }
+            return CloudSQLInstance(
+                connectionName: connectionName,
+                project: project,
+                region: region,
+                name: name,
+                databaseVersion: dbVersion
+            )
+        }
+        .sorted { $0.name < $1.name }
+    }
+}
+
+// MARK: - CloudSQLListError
+
+private enum CloudSQLListError: LocalizedError {
+    case commandFailed
+    case parseError
+
+    var errorDescription: String? {
+        switch self {
+        case .commandFailed:
+            return "gcloud sql instances list failed. Ensure you are authenticated: gcloud auth login"
+        case .parseError:
+            return "Failed to parse gcloud output."
+        }
+    }
+}
+
+// MARK: - Double-click modifier
+
+private extension View {
+    func onDoubleClick(perform action: @escaping () -> Void) -> some View {
+        simultaneousGesture(TapGesture(count: 2).onEnded { action() })
+    }
+}

--- a/Tusk/Views/Sidebar/CloudSQLInstancePickerSheet.swift
+++ b/Tusk/Views/Sidebar/CloudSQLInstancePickerSheet.swift
@@ -130,6 +130,15 @@ struct CloudSQLInstancePickerSheet: View {
                 .onDoubleClick {
                     if let s = selectedInstance { onSelect(s); dismiss() }
                 }
+
+                if instances.count >= 500 {
+                    Text("Showing 500 instances — use the filter to narrow results.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 6)
+                        .background(.bar)
+                }
             }
         }
         .frame(width: 480, height: 380)
@@ -156,7 +165,7 @@ struct CloudSQLInstancePickerSheet: View {
             }
             let proc = Process()
             proc.executableURL = URL(fileURLWithPath: gcloud)
-            proc.arguments     = ["sql", "instances", "list", "--format=json"]
+            proc.arguments     = ["sql", "instances", "list", "--format=json", "--limit=500"]
             let pipe = Pipe()
             proc.standardOutput = pipe
             proc.standardError  = FileHandle.nullDevice
@@ -172,7 +181,9 @@ struct CloudSQLInstancePickerSheet: View {
 
     private nonisolated static func parseInstances(from data: Data) throws -> [CloudSQLInstance] {
         guard let json = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] else {
-            throw CloudSQLListError.parseError
+            let preview = String(data: data.prefix(200), encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? "(binary data)"
+            throw CloudSQLListError.parseError(preview)
         }
         return json.compactMap { item -> CloudSQLInstance? in
             guard
@@ -198,14 +209,14 @@ struct CloudSQLInstancePickerSheet: View {
 
 private enum CloudSQLListError: LocalizedError {
     case commandFailed
-    case parseError
+    case parseError(String)
 
     var errorDescription: String? {
         switch self {
         case .commandFailed:
             return "gcloud sql instances list failed. Ensure you are authenticated: gcloud auth login"
-        case .parseError:
-            return "Failed to parse gcloud output."
+        case .parseError(let preview):
+            return "Failed to parse gcloud output: \(preview)"
         }
     }
 }

--- a/Tusk/Views/Sidebar/SidebarView.swift
+++ b/Tusk/Views/Sidebar/SidebarView.swift
@@ -135,6 +135,7 @@ private struct ConnectionSection: View {
             .union(allEnums.map { $0.schema })
             .union(allSeqs.map { $0.schema })
             .union(allFuncs.map { $0.schema })
+            .union(appState.schemaNamesCache[connection.id] ?? [])
         let uniqueSchemas = allSchemas.sorted {
             if $0 == "public" { return true }
             if $1 == "public" { return false }
@@ -825,6 +826,13 @@ private struct ConnectionHeader: View {
                     .help("Read-only connection")
             }
 
+            if connection.connectionType == .cloudSQL {
+                CloudSQLProxyBadge(
+                    status: appState.proxyStatuses[connection.id],
+                    fontSize: sidebarFontSize
+                )
+            }
+
             if let errorMsg = appState.schemaRefreshErrors[connection.id] {
                 Image(systemName: "exclamationmark.triangle.fill")
                     .font(.system(size: sidebarFontSize - 3))
@@ -903,6 +911,14 @@ private struct ConnectionHeader: View {
                     }
                 }
             }
+            if connection.connectionType == .cloudSQL, isConnected {
+                if case .crashed = appState.proxyStatuses[connection.id] {
+                    Divider()
+                    Button("Restart Proxy") {
+                        Task { try? await appState.restartProxy(for: connection) }
+                    }
+                }
+            }
             Divider()
             Button("Duplicate") { appState.duplicateConnection(connection) }
             Button("Edit…") { appState.editingConnection = connection }
@@ -941,5 +957,29 @@ private struct ConnectionHeader: View {
                 err.runModal()
             }
         }
+    }
+}
+
+// MARK: - Cloud SQL proxy status badge
+
+private struct CloudSQLProxyBadge: View {
+    let status: CloudSQLProxy.Status?
+    let fontSize: Double
+
+    var body: some View {
+        let (icon, tint, label): (String, Color, String) = {
+            switch status {
+            case .running:
+                return ("cloud.fill", .green, "cloud-sql-proxy running")
+            case .crashed(let msg):
+                return ("cloud.slash.fill", .red, "cloud-sql-proxy crashed: \(msg)")
+            default:
+                return ("cloud", .secondary, "cloud-sql-proxy starting…")
+            }
+        }()
+        Image(systemName: icon)
+            .font(.system(size: fontSize - 3))
+            .foregroundStyle(tint)
+            .help(label)
     }
 }


### PR DESCRIPTION
## Summary
- Adds Google Cloud SQL as a first-class connection type, automatically launching and stopping `cloud-sql-proxy` on connect/disconnect
- Instance and database pickers via `gcloud` CLI; ADC support via `gcloud auth print-access-token`; proxy status badge in sidebar
- Post-review hardening: proxy restart on crash, SSL fix, ADC Keychain skip, test-connection proxy leak fix, concurrent call guards

## Issues
Closes #152
Closes #153
Closes #154
Closes #155
Closes #156
Closes #157

## Test plan
- [ ] Add a new Cloud SQL connection — instance picker lists instances, database picker lists databases, Test Connection succeeds
- [ ] Connect and verify proxy badge turns green in sidebar
- [ ] Switch database on a connected Cloud SQL connection
- [ ] Crash the proxy (kill the process) — badge turns red, Restart Proxy menu item appears and reconnects successfully
- [ ] Disconnect — verify cloud-sql-proxy process is terminated
- [ ] Add connection with ADC enabled — password not required, token fetched at connect time
- [ ] Try to save with malformed instance name (e.g. `foo/bar`) — inline validation error shown
- [ ] Open Edit Connection sheet, click Test Connection, dismiss sheet mid-test — verify no lingering proxy process

🤖 Generated with [Claude Code](https://claude.com/claude-code)