### PR TITLE
feat: sidebar tree visual polish — icons, hierarchy, and density

### DIFF
--- a/Tusk/Views/Sidebar/SidebarView.swift
+++ b/Tusk/Views/Sidebar/SidebarView.swift
@@ -126,7 +126,7 @@ private struct ConnectionSection: View {
     /// When `filterText` is non-empty, each schema's object arrays are narrowed to
     /// names containing the filter string (case-insensitive), and schemas with no
     /// matching objects are omitted entirely.
-    var schemas: [(id: String, name: String, tables: [TableInfo], views: [TableInfo], enums: [EnumInfo], sequences: [SequenceInfo], functions: [FunctionInfo])] {
+    var schemas: [(id: String, name: String, tables: [TableInfo], views: [TableInfo], enums: [EnumInfo], sequences: [SequenceInfo], functions: [FunctionInfo], onlyTables: Bool)] {
         let all       = appState.schemaTables[connection.id] ?? []
         let allEnums  = appState.schemaEnums[connection.id] ?? []
         let allSeqs   = appState.schemaSequences[connection.id] ?? []
@@ -156,15 +156,28 @@ private struct ConnectionSection: View {
         // Include connection.id in the row ID so that identically-named schemas
         // across different connections get distinct SwiftUI identities in the
         // flattened List — otherwise @State (isExpanded) is shared between them.
-        let rows = uniqueSchemas.map { schema -> (id: String, name: String, tables: [TableInfo], views: [TableInfo], enums: [EnumInfo], sequences: [SequenceInfo], functions: [FunctionInfo]) in
-            (
+        let rows = uniqueSchemas.map { schema -> (id: String, name: String, tables: [TableInfo], views: [TableInfo], enums: [EnumInfo], sequences: [SequenceInfo], functions: [FunctionInfo], onlyTables: Bool) in
+            // onlyTables computed from unfiltered data so it doesn't flip when
+            // a search filter removes views/enums/etc. from the result set.
+            let unfilteredTables = tablesBySchema[schema] ?? []
+            let unfilteredViews  = viewsBySchema[schema]  ?? []
+            let unfilteredEnums  = enumsBySchema[schema]  ?? []
+            let unfilteredSeqs   = seqsBySchema[schema]   ?? []
+            let unfilteredFuncs  = funcsBySchema[schema]  ?? []
+            let onlyTablesFlag   = !unfilteredTables.isEmpty &&
+                                   unfilteredViews.isEmpty &&
+                                   unfilteredEnums.isEmpty &&
+                                   unfilteredSeqs.isEmpty &&
+                                   unfilteredFuncs.isEmpty
+            return (
                 id:        "\(connection.id)-\(schema)",
                 name:      schema,
-                tables:    (tablesBySchema[schema] ?? []).filter { matches($0.name) },
-                views:     (viewsBySchema[schema]  ?? []).filter { matches($0.name) },
-                enums:     (enumsBySchema[schema]  ?? []).filter { matches($0.name) },
-                sequences: (seqsBySchema[schema]   ?? []).filter { matches($0.name) },
-                functions: (funcsBySchema[schema]  ?? []).filter { matches($0.signature) }
+                tables:    unfilteredTables.filter { matches($0.name) },
+                views:     unfilteredViews.filter  { matches($0.name) },
+                enums:     unfilteredEnums.filter  { matches($0.name) },
+                sequences: unfilteredSeqs.filter   { matches($0.name) },
+                functions: unfilteredFuncs.filter  { matches($0.signature) },
+                onlyTables: onlyTablesFlag
             )
         }
 
@@ -188,6 +201,7 @@ private struct ConnectionSection: View {
                         enums: schema.enums,
                         sequences: schema.sequences,
                         functions: schema.functions,
+                        onlyTables: schema.onlyTables,
                         connection: connection,
                         tableSizes: appState.schemaTableSizes[connection.id] ?? [:]
                     )
@@ -208,6 +222,8 @@ private struct SchemaRow: View {
     let enums: [EnumInfo]
     let sequences: [SequenceInfo]
     let functions: [FunctionInfo]
+    /// Pre-computed from unfiltered data so it doesn't flip during search.
+    let onlyTables: Bool
     let connection: Connection
     var tableSizes: [String: TableSizeInfo] = [:]
 
@@ -216,19 +232,20 @@ private struct SchemaRow: View {
     @AppStorage("tusk.sidebar.fontDesign")    private var sidebarFontDesign: TuskFontDesign = .sansSerif
     @AppStorage("tusk.sidebar.showTableSizes") private var showTableSizes    = false
     @State private var isExpanded: Bool
-    @State private var tablesExpanded: Bool = false
+    @State private var tablesExpanded: Bool = true
     @State private var viewsExpanded: Bool = false
     @State private var enumsExpanded: Bool = false
     @State private var sequencesExpanded: Bool = false
     @State private var functionsExpanded: Bool = false
 
-    init(schema: String, tables: [TableInfo], views: [TableInfo], enums: [EnumInfo], sequences: [SequenceInfo], functions: [FunctionInfo], connection: Connection, tableSizes: [String: TableSizeInfo] = [:]) {
+    init(schema: String, tables: [TableInfo], views: [TableInfo], enums: [EnumInfo], sequences: [SequenceInfo], functions: [FunctionInfo], onlyTables: Bool, connection: Connection, tableSizes: [String: TableSizeInfo] = [:]) {
         self.schema = schema
         self.tables = tables
         self.views = views
         self.enums = enums
         self.sequences = sequences
         self.functions = functions
+        self.onlyTables = onlyTables
         self.connection = connection
         self.tableSizes = tableSizes
         _isExpanded = State(initialValue: schema == "public")
@@ -236,165 +253,180 @@ private struct SchemaRow: View {
 
     var isEmpty: Bool { tables.isEmpty && views.isEmpty && enums.isEmpty && sequences.isEmpty && functions.isEmpty }
 
+    /// System schemas are visually de-emphasised.
+    var isSystemSchema: Bool {
+        let systemNames: Set<String> = ["pg_catalog", "information_schema", "pg_toast"]
+        return systemNames.contains(schema) ||
+               schema.hasPrefix("pg_toast_") ||
+               schema.hasPrefix("pg_temp_")
+    }
+
     var body: some View {
         DisclosureGroup(isExpanded: $isExpanded) {
-            if !tables.isEmpty {
-                DisclosureGroup(isExpanded: $tablesExpanded) {
-                    ForEach(tables) { table in
-                        Label {
-                            HStack(spacing: 4) {
-                                Text(table.name)
+            if onlyTables {
+                // Flatten — no "Tables" wrapper when it's the only category
+                tableRows
+            } else {
+                if !tables.isEmpty {
+                    DisclosureGroup(isExpanded: $tablesExpanded) {
+                        tableRows
+                    } label: {
+                        categoryLabel("Tables", icon: "tablecells", count: tables.count)
+                            .onTapGesture { tablesExpanded.toggle() }
+                            .contextMenu {
+                                if appState.isConnected(connection) && !connection.isReadOnly {
+                                    Button("New Table…") {
+                                        appState.createTableTarget = CreateTableTarget(
+                                            schema: schema,
+                                            connectionID: connection.id
+                                        )
+                                    }
+                                }
+                            }
+                    }
+                    .animation(nil, value: tablesExpanded)
+                }
+                if !views.isEmpty {
+                    DisclosureGroup(isExpanded: $viewsExpanded) {
+                        ForEach(views) { view in
+                            Label {
+                                Text(view.name)
                                     .font(.system(size: sidebarFontSize, design: sidebarFontDesign.design))
-                                if showTableSizes, let info = tableSizes["\(table.schema).\(table.name)"] {
-                                    Text("\(info.totalSize) · \(info.rowEstimate.formatted()) rows · idx \(info.indexSize)")
-                                        .font(.system(size: sidebarFontSize - 2, design: sidebarFontDesign.design))
-                                        .foregroundStyle(.tertiary)
-                                }
+                            } icon: {
+                                Image(systemName: "eye")
                             }
-                        } icon: {
-                            Image(systemName: "tablecells")
+                            .tag(SidebarItem.table(
+                                connectionID: connection.id,
+                                schema: view.schema,
+                                tableName: view.name
+                            ))
                         }
-                        .tag(SidebarItem.table(
-                            connectionID: connection.id,
-                            schema: table.schema,
-                            tableName: table.name
-                        ))
-                        .contextMenu {
-                            if appState.isConnected(connection) && !connection.isReadOnly {
-                                Button("Rename…") { renameTable(table) }
-                                Divider()
-                                Button("Truncate Table…") { truncateTable(table) }
-                                Button("Drop Table…")     { dropTable(table) }
-                            }
-                        }
+                    } label: {
+                        categoryLabel("Views", icon: "eye", count: views.count)
+                            .onTapGesture { viewsExpanded.toggle() }
                     }
-                } label: {
-                    Text("Tables")
-                        .font(.system(size: sidebarFontSize, design: sidebarFontDesign.design))
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .contentShape(Rectangle())
-                        .onTapGesture { tablesExpanded.toggle() }
-                        .contextMenu {
-                            if appState.isConnected(connection) && !connection.isReadOnly {
-                                Button("New Table…") {
-                                    appState.createTableTarget = CreateTableTarget(
-                                        schema: schema,
-                                        connectionID: connection.id
-                                    )
-                                }
+                    .animation(nil, value: viewsExpanded)
+                }
+                if !enums.isEmpty {
+                    DisclosureGroup(isExpanded: $enumsExpanded) {
+                        ForEach(enums) { enumInfo in
+                            EnumValueRow(enumInfo: enumInfo)
+                        }
+                    } label: {
+                        categoryLabel("Enums", icon: "list.bullet", count: enums.count)
+                            .onTapGesture { enumsExpanded.toggle() }
+                    }
+                    .animation(nil, value: enumsExpanded)
+                }
+                if !sequences.isEmpty {
+                    DisclosureGroup(isExpanded: $sequencesExpanded) {
+                        ForEach(sequences) { seq in
+                            Label {
+                                Text(seq.name)
+                                    .font(.system(size: sidebarFontSize, design: sidebarFontDesign.design))
+                            } icon: {
+                                Image(systemName: "arrow.clockwise")
                             }
                         }
+                    } label: {
+                        categoryLabel("Sequences", icon: "arrow.clockwise", count: sequences.count)
+                            .onTapGesture { sequencesExpanded.toggle() }
+                    }
+                    .animation(nil, value: sequencesExpanded)
                 }
-                .animation(nil, value: tablesExpanded)
-            }
-            if !views.isEmpty {
-                DisclosureGroup(isExpanded: $viewsExpanded) {
-                    ForEach(views) { view in
-                        Label {
-                            Text(view.name)
-                                .font(.system(size: sidebarFontSize, design: sidebarFontDesign.design))
-                        } icon: {
-                            Image(systemName: "eye")
+                if !functions.isEmpty {
+                    DisclosureGroup(isExpanded: $functionsExpanded) {
+                        ForEach(functions) { fn in
+                            Label {
+                                Text(fn.signature)
+                                    .font(.system(size: sidebarFontSize, design: sidebarFontDesign.design))
+                            } icon: {
+                                Image(systemName: "function")
+                            }
                         }
-                        .tag(SidebarItem.table(
-                            connectionID: connection.id,
-                            schema: view.schema,
-                            tableName: view.name
-                        ))
+                    } label: {
+                        categoryLabel("Functions", icon: "function", count: functions.count)
+                            .onTapGesture { functionsExpanded.toggle() }
                     }
-                } label: {
-                    Text("Views")
-                        .font(.system(size: sidebarFontSize, design: sidebarFontDesign.design))
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .contentShape(Rectangle())
-                        .onTapGesture { viewsExpanded.toggle() }
+                    .animation(nil, value: functionsExpanded)
                 }
-                .animation(nil, value: viewsExpanded)
-            }
-            if !enums.isEmpty {
-                DisclosureGroup(isExpanded: $enumsExpanded) {
-                    ForEach(enums) { enumInfo in
-                        EnumValueRow(enumInfo: enumInfo)
-                    }
-                } label: {
-                    Text("Enums")
-                        .font(.system(size: sidebarFontSize, design: sidebarFontDesign.design))
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .contentShape(Rectangle())
-                        .onTapGesture { enumsExpanded.toggle() }
-                }
-                .animation(nil, value: enumsExpanded)
-            }
-            if !sequences.isEmpty {
-                DisclosureGroup(isExpanded: $sequencesExpanded) {
-                    ForEach(sequences) { seq in
-                        Label {
-                            Text(seq.name)
-                                .font(.system(size: sidebarFontSize, design: sidebarFontDesign.design))
-                        } icon: {
-                            Image(systemName: "number")
-                        }
-                    }
-                } label: {
-                    Text("Sequences")
-                        .font(.system(size: sidebarFontSize, design: sidebarFontDesign.design))
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .contentShape(Rectangle())
-                        .onTapGesture { sequencesExpanded.toggle() }
-                }
-                .animation(nil, value: sequencesExpanded)
-            }
-            if !functions.isEmpty {
-                DisclosureGroup(isExpanded: $functionsExpanded) {
-                    ForEach(functions) { fn in
-                        Label {
-                            Text(fn.signature)
-                                .font(.system(size: sidebarFontSize, design: sidebarFontDesign.design))
-                        } icon: {
-                            Image(systemName: "function")
-                        }
-                    }
-                } label: {
-                    Text("Functions")
-                        .font(.system(size: sidebarFontSize, design: sidebarFontDesign.design))
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .contentShape(Rectangle())
-                        .onTapGesture { functionsExpanded.toggle() }
-                }
-                .animation(nil, value: functionsExpanded)
             }
         } label: {
-            HStack(spacing: 6) {
-                Text(schema)
-                    .font(.system(size: sidebarFontSize, design: sidebarFontDesign.design))
-                    .foregroundStyle(isEmpty ? .tertiary : .primary)
-                if isEmpty {
-                    Text("empty")
-                        .font(.caption2)
-                        .foregroundStyle(.quaternary)
-                        .padding(.horizontal, 5)
-                        .padding(.vertical, 1)
-                        .background(.quinary, in: Capsule())
+            Text(schema)
+                .font(isEmpty
+                      ? .system(size: sidebarFontSize, design: sidebarFontDesign.design).italic()
+                      : .system(size: sidebarFontSize, design: sidebarFontDesign.design))
+                .foregroundStyle(isEmpty || isSystemSchema ? AnyShapeStyle(.tertiary) : AnyShapeStyle(.primary))
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .contentShape(Rectangle())
+                .onTapGesture { isExpanded.toggle() }
+                .contextMenu {
+                    if appState.isConnected(connection) && !connection.isReadOnly {
+                        Button("New Table…") {
+                            appState.createTableTarget = CreateTableTarget(
+                                schema: schema,
+                                connectionID: connection.id
+                            )
+                        }
+                        Divider()
+                        Button("Rename Schema…") { renameSchema() }
+                        Button("Drop Schema…")   { dropSchema() }
+                    }
                 }
+        }
+        .animation(nil, value: isExpanded)
+    }
+
+    // MARK: - Subviews
+
+    @ViewBuilder
+    private var tableRows: some View {
+        ForEach(tables) { table in
+            Label {
+                HStack(spacing: 4) {
+                    Text(table.name)
+                        .font(.system(size: sidebarFontSize, design: sidebarFontDesign.design))
+                    if showTableSizes, let info = tableSizes["\(table.schema).\(table.name)"] {
+                        Text("\(info.totalSize) · \(info.rowEstimate.formatted()) rows · idx \(info.indexSize)")
+                            .font(.system(size: sidebarFontSize - 2, design: sidebarFontDesign.design))
+                            .foregroundStyle(.tertiary)
+                    }
+                }
+            } icon: {
+                Image(systemName: "tablecells")
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .contentShape(Rectangle())
-            .onTapGesture { isExpanded.toggle() }
+            .tag(SidebarItem.table(
+                connectionID: connection.id,
+                schema: table.schema,
+                tableName: table.name
+            ))
             .contextMenu {
                 if appState.isConnected(connection) && !connection.isReadOnly {
-                    Button("New Table…") {
-                        appState.createTableTarget = CreateTableTarget(
-                            schema: schema,
-                            connectionID: connection.id
-                        )
-                    }
+                    Button("Rename…") { renameTable(table) }
                     Divider()
-                    Button("Rename Schema…") { renameSchema() }
-                    Button("Drop Schema…")   { dropSchema() }
+                    Button("Truncate Table…") { truncateTable(table) }
+                    Button("Drop Table…")     { dropTable(table) }
                 }
             }
         }
-        .animation(nil, value: isExpanded)
+    }
+
+    private func categoryLabel(_ title: String, icon: String, count: Int) -> some View {
+        HStack(spacing: 5) {
+            Image(systemName: icon)
+                .foregroundStyle(.secondary)
+                .font(.system(size: sidebarFontSize - 1))
+                .frame(width: sidebarFontSize)
+            Text(title)
+                .font(.system(size: sidebarFontSize, design: sidebarFontDesign.design))
+            Spacer()
+            Text("\(count)")
+                .font(.system(size: sidebarFontSize - 2, design: sidebarFontDesign.design))
+                .foregroundStyle(.tertiary)
+                .monospacedDigit()
+        }
+        .frame(maxWidth: .infinity)
+        .contentShape(Rectangle())
     }
 
     // MARK: - Rename schema
@@ -639,6 +671,7 @@ private struct UsersAndRolesSection: View {
     @State private var usersExpanded = false
     @State private var rolesExpanded = false
     @State private var showingCreateRole = false
+    @State private var isHovered = false
 
     private var roles: [RoleInfo] { appState.connectionRoles[connection.id] ?? [] }
     private var users: [RoleInfo] { roles.filter { $0.canLogin } }
@@ -723,18 +756,21 @@ private struct UsersAndRolesSection: View {
                     }
                 }
 
-                if isSuperuser && !connection.isReadOnly && appState.clients[connection.id] != nil {
-                    Button {
-                        showingCreateRole = true
-                    } label: {
-                        Image(systemName: "plus")
-                            .font(.system(size: sidebarFontSize - 2))
-                            .foregroundStyle(.secondary)
-                    }
-                    .buttonStyle(.plain)
-                    .help("Create new user or role")
+                let shouldShowCreate = isSuperuser && !connection.isReadOnly && appState.clients[connection.id] != nil && isHovered
+                Button {
+                    showingCreateRole = true
+                } label: {
+                    Image(systemName: "plus")
+                        .font(.system(size: sidebarFontSize - 2))
+                        .foregroundStyle(.secondary)
                 }
+                .buttonStyle(.plain)
+                .help("Create new user or role")
+                .opacity(shouldShowCreate ? 1 : 0)
+                .allowsHitTesting(shouldShowCreate)
+                .accessibilityHidden(!shouldShowCreate)
             }
+            .onHover { isHovered = $0 }
         }
         .animation(nil, value: isExpanded)
         .sheet(isPresented: $showingCreateRole) {


### PR DESCRIPTION
## Summary
- Add SF Symbol icons and count badges to Tables/Views/Enums/Sequences/Functions category headers
- Flatten the "Tables" wrapper when it's the only category in a schema (reduces nesting depth for the common case)
- De-emphasise empty and system schemas with italic/tertiary styling; remove the old "empty" pill badge
- Reveal the Users & Roles "+" button on hover only, using opacity to avoid layout shift
- Expand tables by default when the Tables sub-section is shown

## Issues
Closes #159

## Test plan
- [ ] Connect to a DB with multiple schemas — verify public schema auto-expands and shows tables directly (no "Tables" wrapper)
- [ ] Connect to a DB with tables + views in the same schema — verify "Tables" and "Views" categories each appear with icon and count badge
- [ ] Type a filter that matches only table names (not views) — verify "Tables" wrapper does not disappear mid-search
- [ ] Verify system schemas (pg_catalog, information_schema, pg_toast) appear dimmed/tertiary
- [ ] Verify a user schema named pg_partman (if available) is NOT de-emphasised
- [ ] Hover over Users & Roles — verify "+" button fades in smoothly without layout shift
- [ ] Empty schema — verify italic styling, no "empty" pill badge