### PR TITLE
feat: enum/sequence detail tabs and context menus for sidebar objects

### DIFF
--- a/Tusk.xcodeproj/project.pbxproj
+++ b/Tusk.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0D8DDDD1DAF8C4B529F3301C /* SequenceDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7463E8EFBD3C2C180D34F4A9 /* SequenceDetailView.swift */; };
 		166F02A3D80B0F112F3C008C /* DatabaseClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA3E61CFF0505201909FC54F /* DatabaseClient.swift */; };
 		16C056E3414DCF8938D6DFA4 /* QueryEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54DB2C1EDCFE2EC1D9FC21ED /* QueryEditorView.swift */; };
 		19F8F1956AE3FBCCD1F774D4 /* AddConnectionSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37B4E572B48F16D9767046C1 /* AddConnectionSheet.swift */; };
@@ -16,6 +17,7 @@
 		2A084C868154BFE4D6EF03F6 /* RelationsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D55DC649CC6986737268922 /* RelationsView.swift */; };
 		2E45EA7D8AE4CB19451C82E6 /* QueryResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EBD0E0FCEF86AA688735504 /* QueryResult.swift */; };
 		43CD2524047CB484084FE904 /* PostgresNIO in Frameworks */ = {isa = PBXBuildFile; productRef = FEBBCC182C5C88B35790CB9D /* PostgresNIO */; };
+		4485D687490F834C172D3905 /* EnumDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D9E80D332E3F0E63E0DEBF9 /* EnumDetailView.swift */; };
 		4FF5DD480828FDE70A227CE9 /* TuskCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = A053EBD9CCCEB96B218FE03A /* TuskCommands.swift */; };
 		51A6EB67E1B6BA69959B4E7D /* CreateTableSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2D7A2C8664E78D1A769D1C2 /* CreateTableSheet.swift */; };
 		5EC184771B4FC8EB6B55DF1A /* KeychainManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0031996A15573BA8334CAB25 /* KeychainManager.swift */; };
@@ -63,6 +65,7 @@
 		64EF8F3C6D1DAA9DADEBD38E /* SplitViewAutosave.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplitViewAutosave.swift; sourceTree = "<group>"; };
 		67200EE52B28AE64A17D09E7 /* TuskFontDesign.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TuskFontDesign.swift; sourceTree = "<group>"; };
 		6F7C45A0E07237D92F1C1FC4 /* SSHTunnel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHTunnel.swift; sourceTree = "<group>"; };
+		7463E8EFBD3C2C180D34F4A9 /* SequenceDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SequenceDetailView.swift; sourceTree = "<group>"; };
 		75B070C67054E9379142805B /* ActivityMonitorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityMonitorView.swift; sourceTree = "<group>"; };
 		7CCC2BABC5778B46E7417764 /* SQLHighlighter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLHighlighter.swift; sourceTree = "<group>"; };
 		7D55DC649CC6986737268922 /* RelationsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelationsView.swift; sourceTree = "<group>"; };
@@ -70,6 +73,7 @@
 		934FF1C0EBB58E15CCAFABEA /* DataBrowserView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataBrowserView.swift; sourceTree = "<group>"; };
 		94B3CB106A5350A8C72161B8 /* CloudSQLProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudSQLProxy.swift; sourceTree = "<group>"; };
 		94BE01E87D7E3C7BDDE1D73E /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		9D9E80D332E3F0E63E0DEBF9 /* EnumDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnumDetailView.swift; sourceTree = "<group>"; };
 		9EBD0E0FCEF86AA688735504 /* QueryResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryResult.swift; sourceTree = "<group>"; };
 		A053CF122F6C07ED2D8AB8D8 /* RoleDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoleDetailView.swift; sourceTree = "<group>"; };
 		A053EBD9CCCEB96B218FE03A /* TuskCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TuskCommands.swift; sourceTree = "<group>"; };
@@ -183,10 +187,12 @@
 			children = (
 				75B070C67054E9379142805B /* ActivityMonitorView.swift */,
 				934FF1C0EBB58E15CCAFABEA /* DataBrowserView.swift */,
+				9D9E80D332E3F0E63E0DEBF9 /* EnumDetailView.swift */,
 				F73CB2DC9ECA618E4D65A9DE /* ExplainPlanView.swift */,
 				54DB2C1EDCFE2EC1D9FC21ED /* QueryEditorView.swift */,
 				7D55DC649CC6986737268922 /* RelationsView.swift */,
 				A053CF122F6C07ED2D8AB8D8 /* RoleDetailView.swift */,
+				7463E8EFBD3C2C180D34F4A9 /* SequenceDetailView.swift */,
 				7CCC2BABC5778B46E7417764 /* SQLHighlighter.swift */,
 				07B5D84046EF2C8F752BDD6C /* SQLTextEditor.swift */,
 				D84F6197423F6B815DCFF5EC /* TableDetailView.swift */,
@@ -340,6 +346,7 @@
 				51A6EB67E1B6BA69959B4E7D /* CreateTableSheet.swift in Sources */,
 				D2C2E33CC9F0F6438C8814A7 /* DataBrowserView.swift in Sources */,
 				166F02A3D80B0F112F3C008C /* DatabaseClient.swift in Sources */,
+				4485D687490F834C172D3905 /* EnumDetailView.swift in Sources */,
 				FA1608BC33176CC583BE610B /* ExplainPlanView.swift in Sources */,
 				ED65F385DAFD91259FA6AD73 /* FileExplorerView.swift in Sources */,
 				BEF51C28F2EF37A71F450340 /* HelpView.swift in Sources */,
@@ -351,6 +358,7 @@
 				B4EC8AF4B1FDCE660985FCA1 /* SQLHighlighter.swift in Sources */,
 				A2845865FD833A6DE48D7963 /* SQLTextEditor.swift in Sources */,
 				EBAD0BABD60043A2CFC574C9 /* SSHTunnel.swift in Sources */,
+				0D8DDDD1DAF8C4B529F3301C /* SequenceDetailView.swift in Sources */,
 				B2123B053A58F7D78FEE550A /* SettingsPopover.swift in Sources */,
 				DAECA2B92659612616C8E742 /* SidebarView.swift in Sources */,
 				8BFABBAE3E2552D7B68ED705 /* SplitViewAutosave.swift in Sources */,

--- a/Tusk/AppState.swift
+++ b/Tusk/AppState.swift
@@ -244,6 +244,8 @@ final class AppState {
             case .role(let cid, _): return cid == connection.id
             case .queryEditor(let qid):
                 return queryTabs.first(where: { $0.id == qid })?.connectionID == connection.id
+            case .enumType(let cid, _, _): return cid == connection.id
+            case .sequence(let cid, _, _): return cid == connection.id
             }
         }
         for tab in tabsToClose { closeDetailTab(tab.id) }
@@ -437,6 +439,42 @@ final class AppState {
             title: roleName,
             icon: "person",
             kind: .role(connectionID: connection.id, roleName: roleName)
+        )
+        openTabs.append(tab)
+        activateDetailTab(tab)
+    }
+
+    func openEnumTab(for connection: Connection, schema: String, enumName: String) {
+        if let existing = openTabs.first(where: {
+            if case .enumType(let cid, let s, let n) = $0.kind { return cid == connection.id && s == schema && n == enumName }
+            return false
+        }) {
+            activateDetailTab(existing)
+            return
+        }
+        let tab = DetailTab(
+            id: UUID(),
+            title: enumName,
+            icon: "list.bullet",
+            kind: .enumType(connectionID: connection.id, schema: schema, enumName: enumName)
+        )
+        openTabs.append(tab)
+        activateDetailTab(tab)
+    }
+
+    func openSequenceTab(for connection: Connection, schema: String, sequenceName: String) {
+        if let existing = openTabs.first(where: {
+            if case .sequence(let cid, let s, let n) = $0.kind { return cid == connection.id && s == schema && n == sequenceName }
+            return false
+        }) {
+            activateDetailTab(existing)
+            return
+        }
+        let tab = DetailTab(
+            id: UUID(),
+            title: sequenceName,
+            icon: "arrow.clockwise",
+            kind: .sequence(connectionID: connection.id, schema: schema, sequenceName: sequenceName)
         )
         openTabs.append(tab)
         activateDetailTab(tab)
@@ -663,6 +701,12 @@ final class AppState {
             if let connID = queryTabs.first(where: { $0.id == qid })?.connectionID {
                 selectedConnectionID = connID
             }
+        case .enumType(let cid, _, _):
+            selectedSidebarItem = nil
+            selectedConnectionID = cid
+        case .sequence(let cid, _, _):
+            selectedSidebarItem = nil
+            selectedConnectionID = cid
         }
     }
 
@@ -711,6 +755,8 @@ struct DetailTab: Identifiable, Hashable {
         case activityMonitor(connectionID: UUID)
         case role(connectionID: UUID, roleName: String)
         case queryEditor(queryTabID: UUID)
+        case enumType(connectionID: UUID, schema: String, enumName: String)
+        case sequence(connectionID: UUID, schema: String, sequenceName: String)
     }
 
     static func == (lhs: DetailTab, rhs: DetailTab) -> Bool { lhs.id == rhs.id }

--- a/Tusk/Database/DatabaseClient.swift
+++ b/Tusk/Database/DatabaseClient.swift
@@ -412,7 +412,8 @@ actor DatabaseClient {
                    p.proname,
                    pg_catalog.pg_get_function_arguments(p.oid),
                    CASE p.prokind WHEN 'p' THEN '' ELSE pg_catalog.pg_get_function_result(p.oid) END,
-                   p.oid
+                   p.oid,
+                   pg_catalog.pg_get_function_identity_arguments(p.oid)
             FROM pg_catalog.pg_proc p
             JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
             WHERE n.nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast')
@@ -421,13 +422,14 @@ actor DatabaseClient {
             """)
 
         return result.rows.map { row in
-            let schema  = row[safe: 0]?.displayValue ?? ""
-            let name    = row[safe: 1]?.displayValue ?? ""
-            let args    = row[safe: 2]?.displayValue ?? ""
-            let ret     = row[safe: 3]?.displayValue ?? ""
-            let sig     = ret.isEmpty ? "\(name)(\(args))" : "\(name)(\(args)) → \(ret)"
-            let oid     = UInt32(row[safe: 4]?.displayValue ?? "") ?? 0
-            return FunctionInfo(schema: schema, name: name, signature: sig, oid: oid)
+            let schema       = row[safe: 0]?.displayValue ?? ""
+            let name         = row[safe: 1]?.displayValue ?? ""
+            let args         = row[safe: 2]?.displayValue ?? ""
+            let ret          = row[safe: 3]?.displayValue ?? ""
+            let sig          = ret.isEmpty ? "\(name)(\(args))" : "\(name)(\(args)) → \(ret)"
+            let oid          = UInt32(row[safe: 4]?.displayValue ?? "") ?? 0
+            let identityArgs = row[safe: 5]?.displayValue ?? ""
+            return FunctionInfo(schema: schema, name: name, signature: sig, oid: oid, identityArgs: identityArgs)
         }
     }
 

--- a/Tusk/Database/DatabaseClient.swift
+++ b/Tusk/Database/DatabaseClient.swift
@@ -411,7 +411,8 @@ actor DatabaseClient {
             SELECT n.nspname,
                    p.proname,
                    pg_catalog.pg_get_function_arguments(p.oid),
-                   CASE p.prokind WHEN 'p' THEN '' ELSE pg_catalog.pg_get_function_result(p.oid) END
+                   CASE p.prokind WHEN 'p' THEN '' ELSE pg_catalog.pg_get_function_result(p.oid) END,
+                   p.oid
             FROM pg_catalog.pg_proc p
             JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
             WHERE n.nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast')
@@ -425,8 +426,57 @@ actor DatabaseClient {
             let args    = row[safe: 2]?.displayValue ?? ""
             let ret     = row[safe: 3]?.displayValue ?? ""
             let sig     = ret.isEmpty ? "\(name)(\(args))" : "\(name)(\(args)) → \(ret)"
-            return FunctionInfo(schema: schema, name: name, signature: sig)
+            let oid     = UInt32(row[safe: 4]?.displayValue ?? "") ?? 0
+            return FunctionInfo(schema: schema, name: name, signature: sig, oid: oid)
         }
+    }
+
+    func sequenceDetail(schema: String, name: String) async throws -> SequenceDetail {
+        let s = schema.sqlEscaped
+        let n = name.sqlEscaped
+        let result = try await query("""
+            SELECT s.data_type,
+                   s.start_value,
+                   s.min_value,
+                   s.max_value,
+                   s.increment_by,
+                   s.cycle,
+                   s.last_value,
+                   d.refobjid::regclass::text AS owned_table,
+                   a.attname                  AS owned_column
+            FROM pg_sequences s
+            JOIN pg_class c
+                ON c.relname = s.sequencename
+               AND c.relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = s.schemaname)
+               AND c.relkind = 'S'
+            LEFT JOIN pg_depend d
+                ON d.objid = c.oid AND d.deptype = 'a'
+            LEFT JOIN pg_attribute a
+                ON a.attrelid = d.refobjid AND a.attnum = d.refobjsubid
+            WHERE s.schemaname = '\(s)'
+              AND s.sequencename = '\(n)'
+            """)
+        guard let row = result.rows.first else {
+            throw TuskError.queryFailed("Sequence \(schema).\(name) not found")
+        }
+        let lastValStr  = row[safe: 6]?.displayValue ?? ""
+        let rawOwnedTable  = row[safe: 7]?.displayValue ?? "NULL"
+        let rawOwnedColumn = row[safe: 8]?.displayValue ?? "NULL"
+        let ownedTable:  String? = rawOwnedTable  == "NULL" ? nil : rawOwnedTable
+        let ownedColumn: String? = rawOwnedColumn == "NULL" ? nil : rawOwnedColumn
+        return SequenceDetail(
+            schema:       schema,
+            name:         name,
+            dataType:     row[safe: 0]?.displayValue ?? "",
+            startValue:   Int64(row[safe: 1]?.displayValue ?? "") ?? 1,
+            minValue:     Int64(row[safe: 2]?.displayValue ?? "") ?? 1,
+            maxValue:     Int64(row[safe: 3]?.displayValue ?? "") ?? Int64.max,
+            increment:    Int64(row[safe: 4]?.displayValue ?? "") ?? 1,
+            cycleOption:  (row[safe: 5]?.displayValue ?? "false") == "true",
+            lastValue:    lastValStr == "NULL" || lastValStr.isEmpty ? nil : Int64(lastValStr),
+            ownedByTable: ownedTable,
+            ownedByColumn: ownedColumn
+        )
     }
 
     // MARK: - Raw query

--- a/Tusk/Models/QueryResult.swift
+++ b/Tusk/Models/QueryResult.swift
@@ -126,6 +126,10 @@ func quoteIdentifier(_ name: String) -> String {
     "\"" + name.replacingOccurrences(of: "\"", with: "\"\"") + "\""
 }
 
+func quoteLiteral(_ value: String) -> String {
+    "'" + value.replacingOccurrences(of: "'", with: "''") + "'"
+}
+
 func copyToPasteboard(_ string: String) {
     NSPasteboard.general.clearContents()
     NSPasteboard.general.setString(string, forType: .string)
@@ -263,8 +267,9 @@ struct FunctionInfo: Identifiable, Sendable {
     var id: String { "\(schema).\(signature)" }
     let schema: String
     let name: String
-    let signature: String   // e.g. "my_func(integer, text) → boolean"
-    let oid: UInt32         // pg_proc.oid — used for pg_get_functiondef
+    let signature: String       // e.g. "my_func(integer, text) → boolean"
+    let oid: UInt32             // pg_proc.oid — used for pg_get_functiondef
+    let identityArgs: String    // pg_get_function_identity_arguments — used for DROP FUNCTION
 }
 
 // MARK: - Sequence detail (fetched on demand)

--- a/Tusk/Models/QueryResult.swift
+++ b/Tusk/Models/QueryResult.swift
@@ -126,6 +126,11 @@ func quoteIdentifier(_ name: String) -> String {
     "\"" + name.replacingOccurrences(of: "\"", with: "\"\"") + "\""
 }
 
+func copyToPasteboard(_ string: String) {
+    NSPasteboard.general.clearContents()
+    NSPasteboard.general.setString(string, forType: .string)
+}
+
 private func sqlLiteral(_ cell: QueryCell) -> String {
     switch cell {
     case .null:             return "NULL"
@@ -259,6 +264,23 @@ struct FunctionInfo: Identifiable, Sendable {
     let schema: String
     let name: String
     let signature: String   // e.g. "my_func(integer, text) → boolean"
+    let oid: UInt32         // pg_proc.oid — used for pg_get_functiondef
+}
+
+// MARK: - Sequence detail (fetched on demand)
+
+struct SequenceDetail: Sendable {
+    let schema: String
+    let name: String
+    let dataType: String
+    let startValue: Int64
+    let minValue: Int64
+    let maxValue: Int64
+    let increment: Int64
+    let cycleOption: Bool
+    let lastValue: Int64?       // nil if the sequence has never been used
+    let ownedByTable: String?   // "schema.table" if owned by a serial column
+    let ownedByColumn: String?
 }
 
 // MARK: - App-level errors

--- a/Tusk/Views/ContentView.swift
+++ b/Tusk/Views/ContentView.swift
@@ -101,6 +101,16 @@ struct DetailView: View {
                 let client = queryTab.connectionID.flatMap { appState.clients[$0] }
                 QueryEditorView(tab: queryTab, client: client)
             }
+        case .enumType(let connID, let schema, let enumName):
+            if let client = appState.clients[connID],
+               let connection = appState.connections.first(where: { $0.id == connID }) {
+                EnumDetailView(schema: schema, enumName: enumName, client: client, connection: connection)
+            }
+        case .sequence(let connID, let schema, let sequenceName):
+            if let client = appState.clients[connID],
+               let connection = appState.connections.first(where: { $0.id == connID }) {
+                SequenceDetailView(schema: schema, sequenceName: sequenceName, client: client, connection: connection)
+            }
         }
     }
 }
@@ -155,6 +165,10 @@ private struct DetailTabItem: View {
             return connection(for: connID)?.color.color
         case .queryEditor:
             guard let connID = queryTab?.connectionID else { return nil }
+            return connection(for: connID)?.color.color
+        case .enumType(let connID, _, _):
+            return connection(for: connID)?.color.color
+        case .sequence(let connID, _, _):
             return connection(for: connID)?.color.color
         }
     }

--- a/Tusk/Views/Main/EnumDetailView.swift
+++ b/Tusk/Views/Main/EnumDetailView.swift
@@ -145,8 +145,8 @@ struct EnumDetailView: View {
 
         Task {
             do {
-                let posClause = beforeValue.isEmpty ? "" : " BEFORE \(quoteIdentifier(beforeValue))"
-                let sql = "ALTER TYPE \(quoteIdentifier(schema)).\(quoteIdentifier(enumName)) ADD VALUE \(quoteIdentifier(newValue))\(posClause);"
+                let posClause = beforeValue.isEmpty ? "" : " BEFORE \(quoteLiteral(beforeValue))"
+                let sql = "ALTER TYPE \(quoteIdentifier(schema)).\(quoteIdentifier(enumName)) ADD VALUE \(quoteLiteral(newValue))\(posClause);"
                 _ = try await client.query(sql)
                 try? await appState.refreshSchema(for: connection)
                 await reload()

--- a/Tusk/Views/Main/EnumDetailView.swift
+++ b/Tusk/Views/Main/EnumDetailView.swift
@@ -1,0 +1,213 @@
+import SwiftUI
+
+// MARK: - Enum Detail Tab
+
+struct EnumDetailView: View {
+    let schema: String
+    let enumName: String
+    let client: DatabaseClient
+    let connection: Connection
+
+    @Environment(AppState.self) private var appState
+    @AppStorage("tusk.content.fontSize")   private var contentFontSize   = 13.0
+    @AppStorage("tusk.content.fontDesign") private var contentFontDesign: TuskFontDesign = .sansSerif
+
+    @State private var values: [String] = []
+    @State private var isLoading = true
+    @State private var actionError: String? = nil
+
+    private var isReadOnly: Bool { connection.isReadOnly }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            toolbar
+            Divider()
+            if isLoading {
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 0) {
+                        valuesSection
+                    }
+                    .padding(16)
+                }
+            }
+        }
+        .alert("Action Failed", isPresented: Binding(
+            get: { actionError != nil },
+            set: { if !$0 { actionError = nil } }
+        )) {
+            Button("OK") { actionError = nil }
+        } message: {
+            Text(actionError ?? "")
+        }
+        .task { await reload() }
+    }
+
+    // MARK: - Toolbar
+
+    private var toolbar: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "list.bullet")
+                .foregroundStyle(.secondary)
+            Text("\(schema).\(enumName)")
+                .font(.system(size: contentFontSize, weight: .semibold, design: contentFontDesign.design))
+            Spacer()
+            if !isReadOnly {
+                Button("Add Value…") { addValue() }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                Button("Rename…") { renameEnum() }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                Button("Drop…") { dropEnum() }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                    .tint(.red)
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+    }
+
+    // MARK: - Values section
+
+    private var valuesSection: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Values")
+                .font(.system(size: contentFontSize - 1, weight: .semibold, design: contentFontDesign.design))
+                .foregroundStyle(.secondary)
+                .padding(.bottom, 4)
+            ForEach(Array(values.enumerated()), id: \.offset) { idx, value in
+                HStack(spacing: 10) {
+                    Text("\(idx + 1)")
+                        .font(.system(size: contentFontSize - 1, design: .monospaced))
+                        .foregroundStyle(.tertiary)
+                        .frame(minWidth: 24, alignment: .trailing)
+                    Text(value)
+                        .font(.system(size: contentFontSize, design: contentFontDesign.design))
+                }
+                .padding(.vertical, 3)
+                Divider()
+            }
+            if values.isEmpty {
+                Text("No values")
+                    .font(.system(size: contentFontSize - 1, design: contentFontDesign.design))
+                    .foregroundStyle(.tertiary)
+            }
+        }
+    }
+
+    // MARK: - Actions
+
+    private func reload() async {
+        isLoading = true
+        // Re-fetch from the live cache in AppState if available, else fall back to a direct query.
+        if let cached = appState.schemaEnums[connection.id]?.first(where: { $0.schema == schema && $0.name == enumName }) {
+            values = cached.values
+        } else {
+            if let all = try? await client.enums() {
+                values = all.first(where: { $0.schema == schema && $0.name == enumName })?.values ?? []
+            }
+        }
+        isLoading = false
+    }
+
+    private func addValue() {
+        let alert = NSAlert()
+        alert.messageText = "Add Value to \"\(enumName)\""
+        alert.addButton(withTitle: "Add")
+        alert.addButton(withTitle: "Cancel")
+
+        let field = NSTextField(frame: NSRect(x: 0, y: 0, width: 260, height: 22))
+        field.placeholderString = "new_value"
+        alert.accessoryView = field
+        alert.window.initialFirstResponder = field
+
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+        let newValue = field.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !newValue.isEmpty else { return }
+
+        // Optional BEFORE/AFTER positioning
+        let posAlert = NSAlert()
+        posAlert.messageText = "Position (optional)"
+        posAlert.informativeText = "Insert BEFORE an existing value, or leave blank to append at the end. (Note: PostgreSQL does not support AFTER for enum values.)"
+        posAlert.addButton(withTitle: "Add")
+        posAlert.addButton(withTitle: "Cancel")
+        let posField = NSTextField(frame: NSRect(x: 0, y: 0, width: 260, height: 22))
+        posField.placeholderString = "existing_value (BEFORE) — leave blank to append"
+        posAlert.accessoryView = posField
+        posAlert.window.initialFirstResponder = posField
+
+        guard posAlert.runModal() == .alertFirstButtonReturn else { return }
+        let beforeValue = posField.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        Task {
+            do {
+                let posClause = beforeValue.isEmpty ? "" : " BEFORE \(quoteIdentifier(beforeValue))"
+                let sql = "ALTER TYPE \(quoteIdentifier(schema)).\(quoteIdentifier(enumName)) ADD VALUE \(quoteIdentifier(newValue))\(posClause);"
+                _ = try await client.query(sql)
+                try? await appState.refreshSchema(for: connection)
+                await reload()
+            } catch {
+                actionError = error.localizedDescription
+            }
+        }
+    }
+
+    private func renameEnum() {
+        let alert = NSAlert()
+        alert.messageText = "Rename Enum \"\(enumName)\""
+        alert.addButton(withTitle: "Rename")
+        alert.addButton(withTitle: "Cancel")
+
+        let field = NSTextField(frame: NSRect(x: 0, y: 0, width: 260, height: 22))
+        field.stringValue = enumName
+        field.selectText(nil)
+        alert.accessoryView = field
+        alert.window.initialFirstResponder = field
+
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+        let newName = field.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !newName.isEmpty, newName != enumName else { return }
+
+        Task {
+            do {
+                _ = try await client.query("ALTER TYPE \(quoteIdentifier(schema)).\(quoteIdentifier(enumName)) RENAME TO \(quoteIdentifier(newName));")
+                try? await appState.refreshSchema(for: connection)
+                // Close this tab — the enum name has changed
+                if let tab = appState.openTabs.first(where: {
+                    if case .enumType(let cid, let s, let n) = $0.kind { return cid == connection.id && s == schema && n == enumName }
+                    return false
+                }) { appState.closeDetailTab(tab.id) }
+            } catch {
+                actionError = error.localizedDescription
+            }
+        }
+    }
+
+    private func dropEnum() {
+        let alert = NSAlert()
+        alert.messageText = "Drop Enum \"\(enumName)\"?"
+        alert.informativeText = "This permanently removes the enum type. Any columns using this type must be dropped or changed first."
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "Drop Enum")
+        alert.addButton(withTitle: "Cancel")
+
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+
+        Task {
+            do {
+                _ = try await client.query("DROP TYPE \(quoteIdentifier(schema)).\(quoteIdentifier(enumName));")
+                try? await appState.refreshSchema(for: connection)
+                if let tab = appState.openTabs.first(where: {
+                    if case .enumType(let cid, let s, let n) = $0.kind { return cid == connection.id && s == schema && n == enumName }
+                    return false
+                }) { appState.closeDetailTab(tab.id) }
+            } catch {
+                actionError = error.localizedDescription
+            }
+        }
+    }
+}

--- a/Tusk/Views/Main/SequenceDetailView.swift
+++ b/Tusk/Views/Main/SequenceDetailView.swift
@@ -1,0 +1,210 @@
+import SwiftUI
+
+// MARK: - Sequence Detail Tab
+
+struct SequenceDetailView: View {
+    let schema: String
+    let sequenceName: String
+    let client: DatabaseClient
+    let connection: Connection
+
+    @Environment(AppState.self) private var appState
+    @AppStorage("tusk.content.fontSize")   private var contentFontSize   = 13.0
+    @AppStorage("tusk.content.fontDesign") private var contentFontDesign: TuskFontDesign = .sansSerif
+
+    @State private var detail: SequenceDetail? = nil
+    @State private var isLoading = true
+    @State private var setValueText: String = ""
+    @State private var actionError: String? = nil
+
+    private var isReadOnly: Bool { connection.isReadOnly }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            toolbar
+            Divider()
+            if isLoading {
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if let detail {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 0) {
+                        metadataSection(detail: detail)
+                        if !isReadOnly {
+                            Divider().padding(.vertical, 12)
+                            actionsSection(detail: detail)
+                        }
+                    }
+                    .padding(16)
+                }
+            } else {
+                Text("Failed to load sequence details.")
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        }
+        .alert("Action Failed", isPresented: Binding(
+            get: { actionError != nil },
+            set: { if !$0 { actionError = nil } }
+        )) {
+            Button("OK") { actionError = nil }
+        } message: {
+            Text(actionError ?? "")
+        }
+        .task { await reload() }
+    }
+
+    // MARK: - Toolbar
+
+    private var toolbar: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "arrow.clockwise")
+                .foregroundStyle(.secondary)
+            Text("\(schema).\(sequenceName)")
+                .font(.system(size: contentFontSize, weight: .semibold, design: contentFontDesign.design))
+            Spacer()
+            Button {
+                Task { await reload() }
+            } label: {
+                Image(systemName: "arrow.clockwise")
+            }
+            .buttonStyle(.plain)
+            .help("Refresh")
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+    }
+
+    // MARK: - Metadata section
+
+    private func metadataSection(detail: SequenceDetail) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Properties")
+                .font(.system(size: contentFontSize - 1, weight: .semibold, design: contentFontDesign.design))
+                .foregroundStyle(.secondary)
+                .padding(.bottom, 4)
+
+            row("Data type",    detail.dataType)
+            row("Last value",   detail.lastValue.map { String($0) } ?? "Never used")
+            row("Start value",  String(detail.startValue))
+            row("Min value",    String(detail.minValue))
+            row("Max value",    String(detail.maxValue))
+            row("Increment",    String(detail.increment))
+            row("Cycles",       detail.cycleOption ? "Yes" : "No")
+            if let table = detail.ownedByTable, let col = detail.ownedByColumn {
+                row("Owned by",  "\(table).\(col)")
+            }
+        }
+    }
+
+    private func row(_ label: String, _ value: String) -> some View {
+        HStack(alignment: .top, spacing: 0) {
+            Text(label)
+                .font(.system(size: contentFontSize - 1, design: contentFontDesign.design))
+                .foregroundStyle(.secondary)
+                .frame(width: 120, alignment: .leading)
+            Text(value)
+                .font(.system(size: contentFontSize, design: contentFontDesign.design))
+        }
+        .padding(.vertical, 3)
+    }
+
+    // MARK: - Actions section
+
+    private func actionsSection(detail: SequenceDetail) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Actions")
+                .font(.system(size: contentFontSize - 1, weight: .semibold, design: contentFontDesign.design))
+                .foregroundStyle(.secondary)
+
+            // Set value
+            HStack(spacing: 8) {
+                TextField("New value…", text: $setValueText)
+                    .textFieldStyle(.roundedBorder)
+                    .frame(width: 140)
+                    .font(.system(size: contentFontSize, design: contentFontDesign.design))
+                Button("Set Value") { setvalue() }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                    .disabled(Int64(setValueText) == nil)
+            }
+
+            // Reset to 1
+            Button("Reset to 1…") { resetToOne() }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .tint(.orange)
+
+            // Drop
+            Button("Drop Sequence…") { dropSequence() }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .tint(.red)
+        }
+    }
+
+    // MARK: - Data
+
+    private func reload() async {
+        isLoading = true
+        detail = try? await client.sequenceDetail(schema: schema, name: sequenceName)
+        isLoading = false
+    }
+
+    // MARK: - Mutations
+
+    private func setvalue() {
+        guard let newVal = Int64(setValueText) else { return }
+        Task {
+            do {
+                _ = try await client.query("SELECT setval('\(quoteIdentifier(schema)).\(quoteIdentifier(sequenceName))', \(newVal));")
+                setValueText = ""
+                await reload()
+            } catch {
+                actionError = error.localizedDescription
+            }
+        }
+    }
+
+    private func resetToOne() {
+        let alert = NSAlert()
+        alert.messageText = "Reset \"\(sequenceName)\" to 1?"
+        alert.informativeText = "The next call to nextval() will return 1. This cannot be undone."
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "Reset")
+        alert.addButton(withTitle: "Cancel")
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+
+        Task {
+            do {
+                _ = try await client.query("SELECT setval('\(quoteIdentifier(schema)).\(quoteIdentifier(sequenceName))', 1, false);")
+                await reload()
+            } catch {
+                actionError = error.localizedDescription
+            }
+        }
+    }
+
+    private func dropSequence() {
+        let alert = NSAlert()
+        alert.messageText = "Drop Sequence \"\(sequenceName)\"?"
+        alert.informativeText = "This permanently removes the sequence. Any columns using it via nextval() will fail on the next insert."
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "Drop Sequence")
+        alert.addButton(withTitle: "Cancel")
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+
+        Task {
+            do {
+                _ = try await client.query("DROP SEQUENCE \(quoteIdentifier(schema)).\(quoteIdentifier(sequenceName));")
+                try? await appState.refreshSchema(for: connection)
+                if let tab = appState.openTabs.first(where: {
+                    if case .sequence(let cid, let s, let n) = $0.kind { return cid == connection.id && s == schema && n == sequenceName }
+                    return false
+                }) { appState.closeDetailTab(tab.id) }
+            } catch {
+                actionError = error.localizedDescription
+            }
+        }
+    }
+}

--- a/Tusk/Views/Main/SequenceDetailView.swift
+++ b/Tusk/Views/Main/SequenceDetailView.swift
@@ -157,7 +157,8 @@ struct SequenceDetailView: View {
         guard let newVal = Int64(setValueText) else { return }
         Task {
             do {
-                _ = try await client.query("SELECT setval('\(quoteIdentifier(schema)).\(quoteIdentifier(sequenceName))', \(newVal));")
+                let regclass = "\(quoteIdentifier(schema)).\(quoteIdentifier(sequenceName))".replacingOccurrences(of: "'", with: "''")
+                _ = try await client.query("SELECT setval('\(regclass)', \(newVal));")
                 setValueText = ""
                 await reload()
             } catch {
@@ -177,7 +178,8 @@ struct SequenceDetailView: View {
 
         Task {
             do {
-                _ = try await client.query("SELECT setval('\(quoteIdentifier(schema)).\(quoteIdentifier(sequenceName))', 1, false);")
+                let regclass = "\(quoteIdentifier(schema)).\(quoteIdentifier(sequenceName))".replacingOccurrences(of: "'", with: "''")
+                _ = try await client.query("SELECT setval('\(regclass)', 1, false);")
                 await reload()
             } catch {
                 actionError = error.localizedDescription

--- a/Tusk/Views/Sidebar/SidebarView.swift
+++ b/Tusk/Views/Sidebar/SidebarView.swift
@@ -460,7 +460,8 @@ private struct SchemaRow: View {
         alert.addButton(withTitle: "Cancel")
         guard alert.runModal() == .alertFirstButtonReturn else { return }
         Task {
-            _ = try? await client.query("SELECT setval('\(quoteIdentifier(seq.schema)).\(quoteIdentifier(seq.name))', 1, false);")
+            let regclass = "\(quoteIdentifier(seq.schema)).\(quoteIdentifier(seq.name))".replacingOccurrences(of: "'", with: "''")
+            _ = try? await client.query("SELECT setval('\(regclass)', 1, false);")
         }
     }
 
@@ -511,7 +512,7 @@ private struct SchemaRow: View {
         guard alert.runModal() == .alertFirstButtonReturn else { return }
         Task {
             do {
-                _ = try await client.query("DROP FUNCTION \(quoteIdentifier(fn.schema)).\(quoteIdentifier(fn.name));")
+                _ = try await client.query("DROP FUNCTION \(quoteIdentifier(fn.schema)).\(quoteIdentifier(fn.name))(\(fn.identityArgs));")
                 try? await appState.refreshSchema(for: connection)
             } catch {
                 let err = NSAlert()

--- a/Tusk/Views/Sidebar/SidebarView.swift
+++ b/Tusk/Views/Sidebar/SidebarView.swift
@@ -310,7 +310,7 @@ private struct SchemaRow: View {
                 if !enums.isEmpty {
                     DisclosureGroup(isExpanded: $enumsExpanded) {
                         ForEach(enums) { enumInfo in
-                            EnumValueRow(enumInfo: enumInfo)
+                            EnumValueRow(enumInfo: enumInfo, connection: connection)
                         }
                     } label: {
                         categoryLabel("Enums", icon: "list.bullet", count: enums.count)
@@ -327,6 +327,16 @@ private struct SchemaRow: View {
                             } icon: {
                                 Image(systemName: "arrow.clockwise")
                             }
+                            .onTapGesture { appState.openSequenceTab(for: connection, schema: seq.schema, sequenceName: seq.name) }
+                            .contextMenu {
+                                Button("Copy Name") { copyToPasteboard(seq.name) }
+                                Button("Copy Qualified Name") { copyToPasteboard("\(quoteIdentifier(seq.schema)).\(quoteIdentifier(seq.name))") }
+                                if appState.isConnected(connection) && !connection.isReadOnly {
+                                    Divider()
+                                    Button("Reset to 1…") { resetSequence(seq) }
+                                    Button("Drop Sequence…") { dropSequence(seq) }
+                                }
+                            }
                         }
                     } label: {
                         categoryLabel("Sequences", icon: "arrow.clockwise", count: sequences.count)
@@ -342,6 +352,15 @@ private struct SchemaRow: View {
                                     .font(.system(size: sidebarFontSize, design: sidebarFontDesign.design))
                             } icon: {
                                 Image(systemName: "function")
+                            }
+                            .contextMenu {
+                                Button("Copy Name") { copyToPasteboard(fn.name) }
+                                Button("Copy Signature") { copyToPasteboard(fn.signature) }
+                                Button("Copy CREATE OR REPLACE…") { copyFunctionDDL(fn) }
+                                if appState.isConnected(connection) && !connection.isReadOnly {
+                                    Divider()
+                                    Button("Drop Function…") { dropFunction(fn) }
+                                }
                             }
                         }
                     } label: {
@@ -427,6 +446,81 @@ private struct SchemaRow: View {
         }
         .frame(maxWidth: .infinity)
         .contentShape(Rectangle())
+    }
+
+    // MARK: - Sequence context menu actions
+
+    private func resetSequence(_ seq: SequenceInfo) {
+        guard let client = appState.clients[connection.id] else { return }
+        let alert = NSAlert()
+        alert.messageText = "Reset \"\(seq.name)\" to 1?"
+        alert.informativeText = "The next call to nextval() will return 1."
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "Reset")
+        alert.addButton(withTitle: "Cancel")
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+        Task {
+            _ = try? await client.query("SELECT setval('\(quoteIdentifier(seq.schema)).\(quoteIdentifier(seq.name))', 1, false);")
+        }
+    }
+
+    private func dropSequence(_ seq: SequenceInfo) {
+        guard let client = appState.clients[connection.id] else { return }
+        let alert = NSAlert()
+        alert.messageText = "Drop Sequence \"\(seq.name)\"?"
+        alert.informativeText = "This permanently removes the sequence."
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "Drop Sequence")
+        alert.addButton(withTitle: "Cancel")
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+        Task {
+            do {
+                _ = try await client.query("DROP SEQUENCE \(quoteIdentifier(seq.schema)).\(quoteIdentifier(seq.name));")
+                try? await appState.refreshSchema(for: connection)
+            } catch {
+                let err = NSAlert()
+                err.messageText = "Drop Sequence Failed"
+                err.informativeText = error.localizedDescription
+                err.alertStyle = .warning
+                err.runModal()
+            }
+        }
+    }
+
+    // MARK: - Function context menu actions
+
+    private func copyFunctionDDL(_ fn: FunctionInfo) {
+        guard let client = appState.clients[connection.id] else {
+            copyToPasteboard("-- client not connected")
+            return
+        }
+        Task {
+            let ddl = (try? await client.query("SELECT pg_get_functiondef(\(fn.oid));"))?.rows.first?.first?.displayValue ?? ""
+            copyToPasteboard(ddl.isEmpty ? "-- could not fetch definition" : ddl)
+        }
+    }
+
+    private func dropFunction(_ fn: FunctionInfo) {
+        guard let client = appState.clients[connection.id] else { return }
+        let alert = NSAlert()
+        alert.messageText = "Drop Function \"\(fn.name)\"?"
+        alert.informativeText = "This permanently removes the function: \(fn.signature)"
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "Drop Function")
+        alert.addButton(withTitle: "Cancel")
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+        Task {
+            do {
+                _ = try await client.query("DROP FUNCTION \(quoteIdentifier(fn.schema)).\(quoteIdentifier(fn.name));")
+                try? await appState.refreshSchema(for: connection)
+            } catch {
+                let err = NSAlert()
+                err.messageText = "Drop Function Failed"
+                err.informativeText = error.localizedDescription
+                err.alertStyle = .warning
+                err.runModal()
+            }
+        }
     }
 
     // MARK: - Rename schema
@@ -787,9 +881,13 @@ private struct UsersAndRolesSection: View {
 
 private struct EnumValueRow: View {
     let enumInfo: EnumInfo
+    let connection: Connection
+
+    @Environment(AppState.self) private var appState
     @AppStorage("tusk.sidebar.fontSize")    private var sidebarFontSize   = 13.0
     @AppStorage("tusk.sidebar.fontDesign") private var sidebarFontDesign: TuskFontDesign = .sansSerif
     @State private var isExpanded = false
+    @State private var actionError: String? = nil
 
     var body: some View {
         DisclosureGroup(isExpanded: $isExpanded) {
@@ -806,8 +904,73 @@ private struct EnumValueRow: View {
             } icon: {
                 Image(systemName: "list.bullet")
             }
+            .onTapGesture {
+                appState.openEnumTab(for: connection, schema: enumInfo.schema, enumName: enumInfo.name)
+            }
         }
         .animation(nil, value: isExpanded)
+        .contextMenu {
+            Button("Copy Name") { copyToPasteboard(enumInfo.name) }
+            Button("Copy CREATE TYPE…") { copyEnumDDL() }
+            if appState.isConnected(connection) && !connection.isReadOnly {
+                Divider()
+                Button("Rename…") { renameEnum() }
+                Button("Drop Enum…") { dropEnum() }
+            }
+        }
+        .alert("Action Failed", isPresented: Binding(
+            get: { actionError != nil },
+            set: { if !$0 { actionError = nil } }
+        )) {
+            Button("OK") { actionError = nil }
+        } message: {
+            Text(actionError ?? "")
+        }
+    }
+
+    private func copyEnumDDL() {
+        let values = enumInfo.values.map { "    \(quoteIdentifier($0))" }.joined(separator: ",\n")
+        let ddl = "CREATE TYPE \(quoteIdentifier(enumInfo.schema)).\(quoteIdentifier(enumInfo.name)) AS ENUM (\n\(values)\n);"
+        copyToPasteboard(ddl)
+    }
+
+    private func renameEnum() {
+        guard let client = appState.clients[connection.id] else { return }
+        let alert = NSAlert()
+        alert.messageText = "Rename Enum \"\(enumInfo.name)\""
+        alert.addButton(withTitle: "Rename")
+        alert.addButton(withTitle: "Cancel")
+        let field = NSTextField(frame: NSRect(x: 0, y: 0, width: 260, height: 22))
+        field.stringValue = enumInfo.name
+        field.selectText(nil)
+        alert.accessoryView = field
+        alert.window.initialFirstResponder = field
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+        let newName = field.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !newName.isEmpty, newName != enumInfo.name else { return }
+        Task {
+            do {
+                _ = try await client.query("ALTER TYPE \(quoteIdentifier(enumInfo.schema)).\(quoteIdentifier(enumInfo.name)) RENAME TO \(quoteIdentifier(newName));")
+                try? await appState.refreshSchema(for: connection)
+            } catch { actionError = error.localizedDescription }
+        }
+    }
+
+    private func dropEnum() {
+        guard let client = appState.clients[connection.id] else { return }
+        let alert = NSAlert()
+        alert.messageText = "Drop Enum \"\(enumInfo.name)\"?"
+        alert.informativeText = "This permanently removes the enum type."
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "Drop Enum")
+        alert.addButton(withTitle: "Cancel")
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+        Task {
+            do {
+                _ = try await client.query("DROP TYPE \(quoteIdentifier(enumInfo.schema)).\(quoteIdentifier(enumInfo.name));")
+                try? await appState.refreshSchema(for: connection)
+            } catch { actionError = error.localizedDescription }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Enum types in the sidebar are now clickable — opens a detail tab showing values with ordinal positions, with Add Value (with BEFORE positioning), Rename, and Drop actions
- Sequences in the sidebar are now clickable — opens a detail tab showing full metadata (data type, bounds, increment, cycle), with Set Value, Reset to 1, and Drop actions
- Context menus added to enum values, sequence rows, and function rows in the sidebar (Copy Name, Copy DDL/signature, mutating actions)

## Issues
Closes #161
Closes #162
Closes #165

## Test plan
- [ ] Click an enum type in the sidebar — detail tab opens showing its values
- [ ] Add a value to an enum (with and without BEFORE positioning)
- [ ] Rename and Drop an enum
- [ ] Click a sequence — detail tab opens with metadata
- [ ] Set a custom value and reset a sequence to 1
- [ ] Right-click enum/sequence/function rows in sidebar — context menu appears with correct actions
- [ ] Verify read-only connections hide mutating actions