### PR TITLE
feat: function source viewer tab and executor

### DIFF
--- a/Tusk.xcodeproj/project.pbxproj
+++ b/Tusk.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		88CB8E03F6BAAA888B4887F2 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15B49B9D6360FE850DD93363 /* AppState.swift */; };
 		8BC64A5B72B6437F52A7EC49 /* ActivityMonitorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75B070C67054E9379142805B /* ActivityMonitorView.swift */; };
 		8BFABBAE3E2552D7B68ED705 /* SplitViewAutosave.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64EF8F3C6D1DAA9DADEBD38E /* SplitViewAutosave.swift */; };
+		9EF64556295E01772AA50486 /* FunctionDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F1FC4557C5B581972CE00D /* FunctionDetailView.swift */; };
 		A2845865FD833A6DE48D7963 /* SQLTextEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07B5D84046EF2C8F752BDD6C /* SQLTextEditor.swift */; };
 		B2123B053A58F7D78FEE550A /* SettingsPopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F1C8E9BF3BF31794B0FF27A /* SettingsPopover.swift */; };
 		B3A1EC28832572F3CC389E9B /* Connection.swift in Sources */ = {isa = PBXBuildFile; fileRef = B48A2CA1E506E6FDF0786437 /* Connection.swift */; };
@@ -62,6 +63,7 @@
 		37B4E572B48F16D9767046C1 /* AddConnectionSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddConnectionSheet.swift; sourceTree = "<group>"; };
 		54DB2C1EDCFE2EC1D9FC21ED /* QueryEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryEditorView.swift; sourceTree = "<group>"; };
 		615C3C512A905EBC9A2F5662 /* Tusk.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Tusk.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		61F1FC4557C5B581972CE00D /* FunctionDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FunctionDetailView.swift; sourceTree = "<group>"; };
 		64EF8F3C6D1DAA9DADEBD38E /* SplitViewAutosave.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplitViewAutosave.swift; sourceTree = "<group>"; };
 		67200EE52B28AE64A17D09E7 /* TuskFontDesign.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TuskFontDesign.swift; sourceTree = "<group>"; };
 		6F7C45A0E07237D92F1C1FC4 /* SSHTunnel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHTunnel.swift; sourceTree = "<group>"; };
@@ -189,6 +191,7 @@
 				934FF1C0EBB58E15CCAFABEA /* DataBrowserView.swift */,
 				9D9E80D332E3F0E63E0DEBF9 /* EnumDetailView.swift */,
 				F73CB2DC9ECA618E4D65A9DE /* ExplainPlanView.swift */,
+				61F1FC4557C5B581972CE00D /* FunctionDetailView.swift */,
 				54DB2C1EDCFE2EC1D9FC21ED /* QueryEditorView.swift */,
 				7D55DC649CC6986737268922 /* RelationsView.swift */,
 				A053CF122F6C07ED2D8AB8D8 /* RoleDetailView.swift */,
@@ -349,6 +352,7 @@
 				4485D687490F834C172D3905 /* EnumDetailView.swift in Sources */,
 				FA1608BC33176CC583BE610B /* ExplainPlanView.swift in Sources */,
 				ED65F385DAFD91259FA6AD73 /* FileExplorerView.swift in Sources */,
+				9EF64556295E01772AA50486 /* FunctionDetailView.swift in Sources */,
 				BEF51C28F2EF37A71F450340 /* HelpView.swift in Sources */,
 				5EC184771B4FC8EB6B55DF1A /* KeychainManager.swift in Sources */,
 				16C056E3414DCF8938D6DFA4 /* QueryEditorView.swift in Sources */,

--- a/Tusk/AppState.swift
+++ b/Tusk/AppState.swift
@@ -483,7 +483,7 @@ final class AppState {
 
     func openFunctionTab(for connection: Connection, fn: FunctionInfo) {
         if let existing = openTabs.first(where: {
-            if case .function(let cid, let s, let n, _) = $0.kind { return cid == connection.id && s == fn.schema && n == fn.name }
+            if case .function(let cid, _, _, let o) = $0.kind { return cid == connection.id && o == fn.oid }
             return false
         }) {
             activateDetailTab(existing)

--- a/Tusk/AppState.swift
+++ b/Tusk/AppState.swift
@@ -246,6 +246,7 @@ final class AppState {
                 return queryTabs.first(where: { $0.id == qid })?.connectionID == connection.id
             case .enumType(let cid, _, _): return cid == connection.id
             case .sequence(let cid, _, _): return cid == connection.id
+            case .function(let cid, _, _, _): return cid == connection.id
             }
         }
         for tab in tabsToClose { closeDetailTab(tab.id) }
@@ -480,6 +481,24 @@ final class AppState {
         activateDetailTab(tab)
     }
 
+    func openFunctionTab(for connection: Connection, fn: FunctionInfo) {
+        if let existing = openTabs.first(where: {
+            if case .function(let cid, let s, let n, _) = $0.kind { return cid == connection.id && s == fn.schema && n == fn.name }
+            return false
+        }) {
+            activateDetailTab(existing)
+            return
+        }
+        let tab = DetailTab(
+            id: UUID(),
+            title: fn.name,
+            icon: "function",
+            kind: .function(connectionID: connection.id, schema: fn.schema, functionName: fn.name, oid: fn.oid)
+        )
+        openTabs.append(tab)
+        activateDetailTab(tab)
+    }
+
     func loadTableSizes(for connection: Connection) async {
         guard let client = clients[connection.id] else { return }
         guard let sizes = try? await client.tableSizes() else { return }
@@ -707,6 +726,9 @@ final class AppState {
         case .sequence(let cid, _, _):
             selectedSidebarItem = nil
             selectedConnectionID = cid
+        case .function(let cid, _, _, _):
+            selectedSidebarItem = nil
+            selectedConnectionID = cid
         }
     }
 
@@ -757,6 +779,7 @@ struct DetailTab: Identifiable, Hashable {
         case queryEditor(queryTabID: UUID)
         case enumType(connectionID: UUID, schema: String, enumName: String)
         case sequence(connectionID: UUID, schema: String, sequenceName: String)
+        case function(connectionID: UUID, schema: String, functionName: String, oid: UInt32)
     }
 
     static func == (lhs: DetailTab, rhs: DetailTab) -> Bool { lhs.id == rhs.id }

--- a/Tusk/Database/DatabaseClient.swift
+++ b/Tusk/Database/DatabaseClient.swift
@@ -413,7 +413,8 @@ actor DatabaseClient {
                    pg_catalog.pg_get_function_arguments(p.oid),
                    CASE p.prokind WHEN 'p' THEN '' ELSE pg_catalog.pg_get_function_result(p.oid) END,
                    p.oid,
-                   pg_catalog.pg_get_function_identity_arguments(p.oid)
+                   pg_catalog.pg_get_function_identity_arguments(p.oid),
+                   p.prokind
             FROM pg_catalog.pg_proc p
             JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
             WHERE n.nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast')
@@ -429,7 +430,8 @@ actor DatabaseClient {
             let sig          = ret.isEmpty ? "\(name)(\(args))" : "\(name)(\(args)) → \(ret)"
             let oid          = UInt32(row[safe: 4]?.displayValue ?? "") ?? 0
             let identityArgs = row[safe: 5]?.displayValue ?? ""
-            return FunctionInfo(schema: schema, name: name, signature: sig, oid: oid, identityArgs: identityArgs)
+            let isProcedure  = row[safe: 6]?.displayValue == "p"
+            return FunctionInfo(schema: schema, name: name, signature: sig, oid: oid, identityArgs: identityArgs, isProcedure: isProcedure)
         }
     }
 

--- a/Tusk/Database/DatabaseClient.swift
+++ b/Tusk/Database/DatabaseClient.swift
@@ -445,7 +445,7 @@ actor DatabaseClient {
                    END,
                    p.prosecdef,
                    CASE p.prokind WHEN 'p' THEN '' ELSE pg_catalog.pg_get_function_result(p.oid) END,
-                   pg_catalog.pg_get_functiondef(p.oid),
+                   COALESCE(pg_catalog.pg_get_functiondef(p.oid), '-- source not available'),
                    pg_catalog.pg_get_function_identity_arguments(p.oid),
                    array_to_string(p.proargnames, ',')
             FROM pg_catalog.pg_proc p
@@ -472,7 +472,7 @@ actor DatabaseClient {
         let typeTokens = identityArgs.isEmpty
             ? []
             : identityArgs.components(separatedBy: ", ")
-        let nameTokens = argNamesRaw.isEmpty
+        let nameTokens = (argNamesRaw.isEmpty || argNamesRaw == "NULL")
             ? []
             : argNamesRaw.components(separatedBy: ",")
 

--- a/Tusk/Database/DatabaseClient.swift
+++ b/Tusk/Database/DatabaseClient.swift
@@ -433,6 +433,67 @@ actor DatabaseClient {
         }
     }
 
+    func functionDetail(oid: UInt32) async throws -> FunctionDetail {
+        let result = try await query("""
+            SELECT n.nspname,
+                   p.proname,
+                   l.lanname,
+                   CASE p.provolatile
+                       WHEN 'i' THEN 'IMMUTABLE'
+                       WHEN 's' THEN 'STABLE'
+                       ELSE 'VOLATILE'
+                   END,
+                   p.prosecdef,
+                   CASE p.prokind WHEN 'p' THEN '' ELSE pg_catalog.pg_get_function_result(p.oid) END,
+                   pg_catalog.pg_get_functiondef(p.oid),
+                   pg_catalog.pg_get_function_identity_arguments(p.oid),
+                   array_to_string(p.proargnames, ',')
+            FROM pg_catalog.pg_proc p
+            JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+            JOIN pg_catalog.pg_language l ON l.oid = p.prolang
+            WHERE p.oid = \(oid)
+            """)
+
+        guard let row = result.rows.first else {
+            throw TuskError.queryFailed("Function with oid \(oid) not found")
+        }
+
+        let schema           = row[safe: 0]?.displayValue ?? ""
+        let name             = row[safe: 1]?.displayValue ?? ""
+        let language         = row[safe: 2]?.displayValue ?? ""
+        let volatility       = row[safe: 3]?.displayValue ?? "VOLATILE"
+        let secdef           = row[safe: 4]?.displayValue ?? "false"
+        let returnType       = row[safe: 5]?.displayValue ?? ""
+        let source           = row[safe: 6]?.displayValue ?? ""
+        let identityArgs     = row[safe: 7]?.displayValue ?? ""
+        let argNamesRaw      = row[safe: 8]?.displayValue ?? ""
+
+        // Build FunctionArg list from identity args (types) and proargnames
+        let typeTokens = identityArgs.isEmpty
+            ? []
+            : identityArgs.components(separatedBy: ", ")
+        let nameTokens = argNamesRaw.isEmpty
+            ? []
+            : argNamesRaw.components(separatedBy: ",")
+
+        let arguments: [FunctionArg] = typeTokens.enumerated().map { idx, typeName in
+            let rawName = idx < nameTokens.count ? nameTokens[idx] : ""
+            let argName = rawName.isEmpty ? nil : rawName
+            return FunctionArg(index: idx, name: argName, typeName: typeName.trimmingCharacters(in: .whitespaces))
+        }
+
+        return FunctionDetail(
+            schema:            schema,
+            name:              name,
+            language:          language,
+            volatility:        volatility,
+            isSecurityDefiner: secdef == "true",
+            returnType:        returnType == "NULL" ? "" : returnType,
+            source:            source,
+            arguments:         arguments
+        )
+    }
+
     func sequenceDetail(schema: String, name: String) async throws -> SequenceDetail {
         let s = schema.sqlEscaped
         let n = name.sqlEscaped

--- a/Tusk/Models/QueryResult.swift
+++ b/Tusk/Models/QueryResult.swift
@@ -269,7 +269,8 @@ struct FunctionInfo: Identifiable, Sendable {
     let name: String
     let signature: String       // e.g. "my_func(integer, text) → boolean"
     let oid: UInt32             // pg_proc.oid — used for pg_get_functiondef
-    let identityArgs: String    // pg_get_function_identity_arguments — used for DROP FUNCTION
+    let identityArgs: String    // pg_get_function_identity_arguments — used for DROP FUNCTION/PROCEDURE
+    let isProcedure: Bool       // true when prokind = 'p'
 }
 
 // MARK: - Sequence detail (fetched on demand)

--- a/Tusk/Models/QueryResult.swift
+++ b/Tusk/Models/QueryResult.swift
@@ -288,6 +288,26 @@ struct SequenceDetail: Sendable {
     let ownedByColumn: String?
 }
 
+// MARK: - Function detail (fetched on demand)
+
+struct FunctionArg: Identifiable, Sendable {
+    var id: Int { index }
+    let index: Int
+    let name: String?       // nil when the argument is unnamed
+    let typeName: String    // e.g. "integer", "text", "character varying"
+}
+
+struct FunctionDetail: Sendable {
+    let schema: String
+    let name: String
+    let language: String        // plpgsql, sql, c, …
+    let volatility: String      // VOLATILE / STABLE / IMMUTABLE
+    let isSecurityDefiner: Bool
+    let returnType: String      // empty string for procedures
+    let source: String          // full CREATE OR REPLACE FUNCTION … text
+    let arguments: [FunctionArg]
+}
+
 // MARK: - App-level errors
 
 enum TuskError: LocalizedError {

--- a/Tusk/Views/ContentView.swift
+++ b/Tusk/Views/ContentView.swift
@@ -111,6 +111,11 @@ struct DetailView: View {
                let connection = appState.connections.first(where: { $0.id == connID }) {
                 SequenceDetailView(schema: schema, sequenceName: sequenceName, client: client, connection: connection)
             }
+        case .function(let connID, _, _, let oid):
+            if let client = appState.clients[connID],
+               let connection = appState.connections.first(where: { $0.id == connID }) {
+                FunctionDetailView(oid: oid, client: client, connection: connection)
+            }
         }
     }
 }
@@ -169,6 +174,8 @@ private struct DetailTabItem: View {
         case .enumType(let connID, _, _):
             return connection(for: connID)?.color.color
         case .sequence(let connID, _, _):
+            return connection(for: connID)?.color.color
+        case .function(let connID, _, _, _):
             return connection(for: connID)?.color.color
         }
     }

--- a/Tusk/Views/Main/FunctionDetailView.swift
+++ b/Tusk/Views/Main/FunctionDetailView.swift
@@ -1,0 +1,306 @@
+import SwiftUI
+
+// MARK: - Function Detail Tab
+
+struct FunctionDetailView: View {
+    let oid: UInt32
+    let client: DatabaseClient
+    let connection: Connection
+
+    @Environment(AppState.self) private var appState
+    @AppStorage("tusk.content.fontSize")   private var contentFontSize   = 13.0
+    @AppStorage("tusk.content.fontDesign") private var contentFontDesign: TuskFontDesign = .sansSerif
+
+    @State private var detail: FunctionDetail? = nil
+    @State private var isLoading = true
+    @State private var isExecutorVisible = false
+
+    private var isReadOnly: Bool { connection.isReadOnly }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            toolbar
+            Divider()
+            if isLoading {
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if let detail {
+                if isExecutorVisible {
+                    VSplitView {
+                        sourcePane(detail: detail)
+                            .frame(minHeight: 120)
+                        ExecutorPane(detail: detail, client: client, isReadOnly: isReadOnly)
+                            .frame(minHeight: 120)
+                    }
+                } else {
+                    sourcePane(detail: detail)
+                }
+            } else {
+                Text("Failed to load function details.")
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        }
+        .task { await reload() }
+    }
+
+    // MARK: - Toolbar
+
+    private var toolbar: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "function")
+                .foregroundStyle(.secondary)
+            Text(detail.map { "\($0.schema).\($0.name)" } ?? "…")
+                .font(.system(size: contentFontSize, weight: .semibold, design: contentFontDesign.design))
+            Spacer()
+            if let detail, !isLoading {
+                metadataBadges(detail: detail)
+                if !isReadOnly {
+                    Toggle(isOn: $isExecutorVisible) {
+                        Label("Run", systemImage: "play.fill")
+                            .font(.callout)
+                    }
+                    .toggleStyle(.button)
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                    Button("Drop…") { dropFunction(detail) }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                        .tint(.red)
+                }
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+    }
+
+    @ViewBuilder
+    private func metadataBadges(detail: FunctionDetail) -> some View {
+        HStack(spacing: 6) {
+            badge(detail.language.uppercased(), color: .blue)
+            badge(detail.volatility, color: volatilityColor(detail.volatility))
+            if detail.isSecurityDefiner {
+                badge("SECURITY DEFINER", color: .orange)
+            }
+            if !detail.returnType.isEmpty && detail.returnType != "NULL" {
+                Text("→ \(detail.returnType)")
+                    .font(.system(size: contentFontSize - 1, design: .monospaced))
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private func badge(_ text: String, color: Color) -> some View {
+        Text(text)
+            .font(.system(size: contentFontSize - 2, weight: .medium, design: .monospaced))
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(color.opacity(0.12), in: RoundedRectangle(cornerRadius: 4))
+            .foregroundStyle(color)
+    }
+
+    private func volatilityColor(_ v: String) -> Color {
+        switch v {
+        case "IMMUTABLE": return .green
+        case "STABLE":    return .teal
+        default:          return .secondary
+        }
+    }
+
+    // MARK: - Source pane
+
+    private func sourcePane(detail: FunctionDetail) -> some View {
+        SQLTextEditor(
+            text: .constant(detail.source),
+            fontSize: contentFontSize,
+            isEditable: false
+        )
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: - Actions
+
+    private func reload() async {
+        isLoading = true
+        detail = try? await client.functionDetail(oid: oid)
+        isLoading = false
+    }
+
+    private func dropFunction(_ detail: FunctionDetail) {
+        let alert = NSAlert()
+        alert.messageText = "Drop Function \"\(detail.name)\"?"
+        alert.informativeText = "This permanently removes the function: \(detail.schema).\(detail.name)(\(detail.arguments.map { $0.typeName }.joined(separator: ", ")))"
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "Drop Function")
+        alert.addButton(withTitle: "Cancel")
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+
+        Task {
+            do {
+                let argTypes = detail.arguments.map { $0.typeName }.joined(separator: ", ")
+                _ = try await client.query("DROP FUNCTION \(quoteIdentifier(detail.schema)).\(quoteIdentifier(detail.name))(\(argTypes));")
+                try? await appState.refreshSchema(for: connection)
+                if let tab = appState.openTabs.first(where: {
+                    if case .function(let cid, let s, let n, _) = $0.kind {
+                        return cid == connection.id && s == detail.schema && n == detail.name
+                    }
+                    return false
+                }) { appState.closeDetailTab(tab.id) }
+            } catch {
+                let err = NSAlert()
+                err.messageText = "Drop Function Failed"
+                err.informativeText = error.localizedDescription
+                err.alertStyle = .warning
+                err.runModal()
+            }
+        }
+    }
+}
+
+// MARK: - Executor pane
+
+private struct ExecutorPane: View {
+    let detail: FunctionDetail
+    let client: DatabaseClient
+    let isReadOnly: Bool
+
+    @AppStorage("tusk.content.fontSize")   private var contentFontSize   = 13.0
+    @AppStorage("tusk.content.fontDesign") private var contentFontDesign: TuskFontDesign = .sansSerif
+
+    @State private var argValues: [String] = []
+    @State private var result: QueryResult? = nil
+    @State private var errorMessage: String? = nil
+    @State private var isRunning = false
+
+    private var inArgs: [FunctionArg] { detail.arguments }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            executorToolbar
+            Divider()
+            if let result {
+                ResultsGrid(result: result)
+            } else if let errorMessage {
+                ScrollView {
+                    Text(errorMessage)
+                        .font(.system(size: contentFontSize - 1, design: .monospaced))
+                        .foregroundStyle(.red)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(12)
+                }
+                .background(Color(nsColor: .textBackgroundColor))
+            } else {
+                Color(nsColor: .textBackgroundColor)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        }
+        .onAppear {
+            argValues = Array(repeating: "", count: inArgs.count)
+        }
+    }
+
+    private var executorToolbar: some View {
+        HStack(spacing: 10) {
+            if inArgs.isEmpty {
+                Text("No parameters")
+                    .font(.system(size: contentFontSize - 1))
+                    .foregroundStyle(.secondary)
+            } else {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 8) {
+                        ForEach(inArgs) { arg in
+                            argField(arg)
+                        }
+                    }
+                    .padding(.vertical, 4)
+                }
+            }
+            Spacer()
+            if isRunning {
+                ProgressView().controlSize(.small)
+            }
+            Button {
+                Task { await execute() }
+            } label: {
+                Label("Execute", systemImage: "play.fill")
+                    .font(.callout)
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.small)
+            .disabled(isRunning)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(.bar)
+    }
+
+    private func argField(_ arg: FunctionArg) -> some View {
+        let label = arg.name.map { "\($0): \(arg.typeName)" } ?? arg.typeName
+        let binding = Binding<String>(
+            get: { arg.index < argValues.count ? argValues[arg.index] : "" },
+            set: { if arg.index < argValues.count { argValues[arg.index] = $0 } }
+        )
+
+        return VStack(alignment: .leading, spacing: 2) {
+            Text(label)
+                .font(.system(size: contentFontSize - 2))
+                .foregroundStyle(.secondary)
+            if isBoolType(arg.typeName) {
+                Toggle("", isOn: Binding(
+                    get: { binding.wrappedValue.lowercased() == "true" },
+                    set: { binding.wrappedValue = $0 ? "true" : "false" }
+                ))
+                .toggleStyle(.checkbox)
+                .labelsHidden()
+            } else {
+                TextField(arg.typeName, text: binding)
+                    .font(.system(size: contentFontSize, design: .monospaced))
+                    .textFieldStyle(.roundedBorder)
+                    .frame(minWidth: 80, maxWidth: 200)
+                    .controlSize(.small)
+            }
+        }
+    }
+
+    private func isBoolType(_ typeName: String) -> Bool {
+        let t = typeName.lowercased()
+        return t == "boolean" || t == "bool"
+    }
+
+    private func execute() async {
+        isRunning = true
+        errorMessage = nil
+        result = nil
+
+        let schema = detail.schema
+        let name   = detail.name
+        let isProcedure = detail.returnType.isEmpty
+
+        // Build argument list: cast each value to its declared type
+        let argList: String
+        if inArgs.isEmpty {
+            argList = ""
+        } else {
+            argList = inArgs.enumerated().map { idx, arg in
+                let val = idx < argValues.count ? argValues[idx] : ""
+                return "\(quoteLiteral(val))::\(arg.typeName)"
+            }.joined(separator: ", ")
+        }
+
+        let sql: String
+        if isProcedure {
+            sql = "CALL \(quoteIdentifier(schema)).\(quoteIdentifier(name))(\(argList));"
+        } else {
+            sql = "SELECT * FROM \(quoteIdentifier(schema)).\(quoteIdentifier(name))(\(argList));"
+        }
+
+        do {
+            let r = try await client.query(sql)
+            result = r
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+
+        isRunning = false
+    }
+}

--- a/Tusk/Views/Main/FunctionDetailView.swift
+++ b/Tusk/Views/Main/FunctionDetailView.swift
@@ -55,7 +55,7 @@ struct FunctionDetailView: View {
             Spacer()
             if let detail, !isLoading {
                 metadataBadges(detail: detail)
-                if !isReadOnly {
+                if !isReadOnly || detail.volatility != "VOLATILE" {
                     Toggle(isOn: $isExecutorVisible) {
                         Label("Run", systemImage: "play.fill")
                             .font(.callout)
@@ -63,6 +63,8 @@ struct FunctionDetailView: View {
                     .toggleStyle(.button)
                     .buttonStyle(.bordered)
                     .controlSize(.small)
+                }
+                if !isReadOnly {
                     Button("Drop…") { dropFunction(detail) }
                         .buttonStyle(.bordered)
                         .controlSize(.small)
@@ -164,8 +166,7 @@ private struct ExecutorPane: View {
     let client: DatabaseClient
     let isReadOnly: Bool
 
-    @AppStorage("tusk.content.fontSize")   private var contentFontSize   = 13.0
-    @AppStorage("tusk.content.fontDesign") private var contentFontDesign: TuskFontDesign = .sansSerif
+    @AppStorage("tusk.content.fontSize") private var contentFontSize = 13.0
 
     @State private var argValues: [String] = []
     @State private var result: QueryResult? = nil
@@ -283,7 +284,7 @@ private struct ExecutorPane: View {
         } else {
             argList = inArgs.enumerated().map { idx, arg in
                 let val = idx < argValues.count ? argValues[idx] : ""
-                return "\(quoteLiteral(val))::\(arg.typeName)"
+                return val.isEmpty ? "NULL" : "\(quoteLiteral(val))::\(arg.typeName)"
             }.joined(separator: ", ")
         }
 

--- a/Tusk/Views/Main/FunctionDetailView.swift
+++ b/Tusk/Views/Main/FunctionDetailView.swift
@@ -129,18 +129,23 @@ struct FunctionDetailView: View {
     }
 
     private func dropFunction(_ detail: FunctionDetail) {
+        let isProcedure = detail.returnType.isEmpty
+        let kind = isProcedure ? "Procedure" : "Function"
         let alert = NSAlert()
-        alert.messageText = "Drop Function \"\(detail.name)\"?"
-        alert.informativeText = "This permanently removes the function: \(detail.schema).\(detail.name)(\(detail.arguments.map { $0.typeName }.joined(separator: ", ")))"
+        alert.messageText = "Drop \(kind) \"\(detail.name)\"?"
+        alert.informativeText = "This permanently removes the \(kind.lowercased()): \(detail.schema).\(detail.name)(\(detail.arguments.map { $0.typeName }.joined(separator: ", ")))"
         alert.alertStyle = .warning
-        alert.addButton(withTitle: "Drop Function")
+        alert.addButton(withTitle: "Drop \(kind)")
         alert.addButton(withTitle: "Cancel")
         guard alert.runModal() == .alertFirstButtonReturn else { return }
 
         Task {
             do {
                 let argTypes = detail.arguments.map { $0.typeName }.joined(separator: ", ")
-                _ = try await client.query("DROP FUNCTION \(quoteIdentifier(detail.schema)).\(quoteIdentifier(detail.name))(\(argTypes));")
+                let dropSQL = isProcedure
+                    ? "DROP PROCEDURE \(quoteIdentifier(detail.schema)).\(quoteIdentifier(detail.name))(\(argTypes));"
+                    : "DROP FUNCTION \(quoteIdentifier(detail.schema)).\(quoteIdentifier(detail.name))(\(argTypes));"
+                _ = try await client.query(dropSQL)
                 try? await appState.refreshSchema(for: connection)
                 if let tab = appState.openTabs.first(where: {
                     if case .function(let cid, let s, let n, _) = $0.kind {

--- a/Tusk/Views/Sidebar/SidebarView.swift
+++ b/Tusk/Views/Sidebar/SidebarView.swift
@@ -504,20 +504,24 @@ private struct SchemaRow: View {
 
     private func dropFunction(_ fn: FunctionInfo) {
         guard let client = appState.clients[connection.id] else { return }
+        let kind = fn.isProcedure ? "Procedure" : "Function"
         let alert = NSAlert()
-        alert.messageText = "Drop Function \"\(fn.name)\"?"
-        alert.informativeText = "This permanently removes the function: \(fn.signature)"
+        alert.messageText = "Drop \(kind) \"\(fn.name)\"?"
+        alert.informativeText = "This permanently removes the \(kind.lowercased()): \(fn.signature)"
         alert.alertStyle = .warning
-        alert.addButton(withTitle: "Drop Function")
+        alert.addButton(withTitle: "Drop \(kind)")
         alert.addButton(withTitle: "Cancel")
         guard alert.runModal() == .alertFirstButtonReturn else { return }
         Task {
             do {
-                _ = try await client.query("DROP FUNCTION \(quoteIdentifier(fn.schema)).\(quoteIdentifier(fn.name))(\(fn.identityArgs));")
+                let dropSQL = fn.isProcedure
+                    ? "DROP PROCEDURE \(quoteIdentifier(fn.schema)).\(quoteIdentifier(fn.name))(\(fn.identityArgs));"
+                    : "DROP FUNCTION \(quoteIdentifier(fn.schema)).\(quoteIdentifier(fn.name))(\(fn.identityArgs));"
+                _ = try await client.query(dropSQL)
                 try? await appState.refreshSchema(for: connection)
             } catch {
                 let err = NSAlert()
-                err.messageText = "Drop Function Failed"
+                err.messageText = "Drop \(kind) Failed"
                 err.informativeText = error.localizedDescription
                 err.alertStyle = .warning
                 err.runModal()

--- a/Tusk/Views/Sidebar/SidebarView.swift
+++ b/Tusk/Views/Sidebar/SidebarView.swift
@@ -232,7 +232,7 @@ private struct SchemaRow: View {
     @AppStorage("tusk.sidebar.fontDesign")    private var sidebarFontDesign: TuskFontDesign = .sansSerif
     @AppStorage("tusk.sidebar.showTableSizes") private var showTableSizes    = false
     @State private var isExpanded: Bool
-    @State private var tablesExpanded: Bool = true
+    @State private var tablesExpanded: Bool = false
     @State private var viewsExpanded: Bool = false
     @State private var enumsExpanded: Bool = false
     @State private var sequencesExpanded: Bool = false
@@ -248,7 +248,7 @@ private struct SchemaRow: View {
         self.onlyTables = onlyTables
         self.connection = connection
         self.tableSizes = tableSizes
-        _isExpanded = State(initialValue: schema == "public")
+        _isExpanded = State(initialValue: false)
     }
 
     var isEmpty: Bool { tables.isEmpty && views.isEmpty && enums.isEmpty && sequences.isEmpty && functions.isEmpty }

--- a/Tusk/Views/Sidebar/SidebarView.swift
+++ b/Tusk/Views/Sidebar/SidebarView.swift
@@ -353,6 +353,7 @@ private struct SchemaRow: View {
                             } icon: {
                                 Image(systemName: "function")
                             }
+                            .onTapGesture { appState.openFunctionTab(for: connection, fn: fn) }
                             .contextMenu {
                                 Button("Copy Name") { copyToPasteboard(fn.name) }
                                 Button("Copy Signature") { copyToPasteboard(fn.signature) }


### PR DESCRIPTION
## Summary
- Clicking a function/procedure in the sidebar opens a detail tab with full CREATE OR REPLACE source (syntax highlighted, read-only), language/volatility/security definer badges, and a Drop button (write connections only)
- Run button toggles an inline executor panel with auto-generated parameter fields per argument; Execute calls the function and shows results in a data grid
- Sidebar schemas and Tables category now start collapsed by default

## Issues
Closes #163
Closes #164

## Test plan
- [ ] Click a function in the sidebar — detail tab opens with highlighted source
- [ ] Metadata badges (language, volatility, security definer, return type) appear correctly
- [ ] Run button appears for write connections and for STABLE/IMMUTABLE on read-only
- [ ] Executor shows one field per parameter, labelled with name and type
- [ ] Empty fields send NULL; filled fields are cast to the declared type
- [ ] SETOF/TABLE return renders in results grid; scalar return shows as single row
- [ ] Errors from execution shown inline (not as an alert)
- [ ] Drop prompts for confirmation and closes the tab
- [ ] Overloaded functions (same name, different signatures) each open their own tab
- [ ] Schemas and Tables are collapsed by default on fresh connect