### PR TITLE
ux: polish enum, sequence, and function detail views

### DIFF
--- a/Tusk/Views/Main/EnumDetailView.swift
+++ b/Tusk/Views/Main/EnumDetailView.swift
@@ -14,7 +14,9 @@ struct EnumDetailView: View {
 
     @State private var values: [String] = []
     @State private var isLoading = true
+    @State private var loadFailed = false
     @State private var actionError: String? = nil
+    @State private var showAddValueSheet = false
 
     private var isReadOnly: Bool { connection.isReadOnly }
 
@@ -25,6 +27,16 @@ struct EnumDetailView: View {
             if isLoading {
                 ProgressView()
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if loadFailed {
+                ContentUnavailableView {
+                    Label("Failed to Load Enum", systemImage: "exclamationmark.triangle")
+                } description: {
+                    Text("Could not retrieve values for \(schema).\(enumName).")
+                } actions: {
+                    Button("Retry") { Task { await reload() } }
+                        .buttonStyle(.bordered)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
                 ScrollView {
                     VStack(alignment: .leading, spacing: 0) {
@@ -33,6 +45,25 @@ struct EnumDetailView: View {
                     .padding(16)
                 }
             }
+        }
+        .sheet(isPresented: $showAddValueSheet) {
+            AddEnumValueSheet(
+                enumName: enumName,
+                existingValues: values,
+                onAdd: { newValue, beforeValue in
+                    Task {
+                        do {
+                            let posClause = beforeValue.map { " BEFORE \(quoteLiteral($0))" } ?? ""
+                            let sql = "ALTER TYPE \(quoteIdentifier(schema)).\(quoteIdentifier(enumName)) ADD VALUE \(quoteLiteral(newValue))\(posClause);"
+                            _ = try await client.query(sql)
+                            try? await appState.refreshSchema(for: connection)
+                            await reload()
+                        } catch {
+                            actionError = error.localizedDescription
+                        }
+                    }
+                }
+            )
         }
         .alert("Action Failed", isPresented: Binding(
             get: { actionError != nil },
@@ -55,7 +86,7 @@ struct EnumDetailView: View {
                 .font(.system(size: contentFontSize, weight: .semibold, design: contentFontDesign.design))
             Spacer()
             if !isReadOnly {
-                Button("Add Value…") { addValue() }
+                Button("Add Value…") { showAddValueSheet = true }
                     .buttonStyle(.bordered)
                     .controlSize(.small)
                 Button("Rename…") { renameEnum() }
@@ -89,6 +120,11 @@ struct EnumDetailView: View {
                         .font(.system(size: contentFontSize, design: contentFontDesign.design))
                 }
                 .padding(.vertical, 3)
+                .contextMenu {
+                    if !isReadOnly {
+                        Button("Rename Value…") { renameValue(value) }
+                    }
+                }
                 Divider()
             }
             if values.isEmpty {
@@ -103,51 +139,39 @@ struct EnumDetailView: View {
 
     private func reload() async {
         isLoading = true
+        loadFailed = false
         // Re-fetch from the live cache in AppState if available, else fall back to a direct query.
         if let cached = appState.schemaEnums[connection.id]?.first(where: { $0.schema == schema && $0.name == enumName }) {
             values = cached.values
         } else {
             if let all = try? await client.enums() {
                 values = all.first(where: { $0.schema == schema && $0.name == enumName })?.values ?? []
+            } else {
+                loadFailed = true
             }
         }
         isLoading = false
     }
 
-    private func addValue() {
+    private func renameValue(_ oldValue: String) {
         let alert = NSAlert()
-        alert.messageText = "Add Value to \"\(enumName)\""
-        alert.addButton(withTitle: "Add")
+        alert.messageText = "Rename Value \"\(oldValue)\""
+        alert.addButton(withTitle: "Rename")
         alert.addButton(withTitle: "Cancel")
 
         let field = NSTextField(frame: NSRect(x: 0, y: 0, width: 260, height: 22))
-        field.placeholderString = "new_value"
+        field.stringValue = oldValue
+        field.selectText(nil)
         alert.accessoryView = field
         alert.window.initialFirstResponder = field
 
         guard alert.runModal() == .alertFirstButtonReturn else { return }
         let newValue = field.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !newValue.isEmpty else { return }
-
-        // Optional BEFORE/AFTER positioning
-        let posAlert = NSAlert()
-        posAlert.messageText = "Position (optional)"
-        posAlert.informativeText = "Insert BEFORE an existing value, or leave blank to append at the end. (Note: PostgreSQL does not support AFTER for enum values.)"
-        posAlert.addButton(withTitle: "Add")
-        posAlert.addButton(withTitle: "Cancel")
-        let posField = NSTextField(frame: NSRect(x: 0, y: 0, width: 260, height: 22))
-        posField.placeholderString = "existing_value (BEFORE) — leave blank to append"
-        posAlert.accessoryView = posField
-        posAlert.window.initialFirstResponder = posField
-
-        guard posAlert.runModal() == .alertFirstButtonReturn else { return }
-        let beforeValue = posField.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !newValue.isEmpty, newValue != oldValue else { return }
 
         Task {
             do {
-                let posClause = beforeValue.isEmpty ? "" : " BEFORE \(quoteLiteral(beforeValue))"
-                let sql = "ALTER TYPE \(quoteIdentifier(schema)).\(quoteIdentifier(enumName)) ADD VALUE \(quoteLiteral(newValue))\(posClause);"
-                _ = try await client.query(sql)
+                _ = try await client.query("ALTER TYPE \(quoteIdentifier(schema)).\(quoteIdentifier(enumName)) RENAME VALUE \(quoteLiteral(oldValue)) TO \(quoteLiteral(newValue));")
                 try? await appState.refreshSchema(for: connection)
                 await reload()
             } catch {
@@ -209,5 +233,66 @@ struct EnumDetailView: View {
                 actionError = error.localizedDescription
             }
         }
+    }
+}
+
+// MARK: - Add Enum Value Sheet
+
+private struct AddEnumValueSheet: View {
+    let enumName: String
+    let existingValues: [String]
+    let onAdd: (String, String?) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @AppStorage("tusk.content.fontSize") private var contentFontSize = 13.0
+
+    @State private var newValue = ""
+    @State private var insertBefore: String = ""   // empty string = append
+
+    private var isValid: Bool { !newValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Add Value to \"\(enumName)\"")
+                .font(.headline)
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Value name")
+                    .font(.system(size: contentFontSize - 1))
+                    .foregroundStyle(.secondary)
+                TextField("new_value", text: $newValue)
+                    .textFieldStyle(.roundedBorder)
+                    .font(.system(size: contentFontSize, design: .monospaced))
+            }
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Position (optional)")
+                    .font(.system(size: contentFontSize - 1))
+                    .foregroundStyle(.secondary)
+                Picker("Insert before", selection: $insertBefore) {
+                    Text("Append at end").tag("")
+                    ForEach(existingValues, id: \.self) { v in
+                        Text("Before \"\(v)\"").tag(v)
+                    }
+                }
+                .labelsHidden()
+            }
+
+            HStack {
+                Spacer()
+                Button("Cancel") { dismiss() }
+                    .keyboardShortcut(.cancelAction)
+                Button("Add Value") {
+                    let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
+                    let before: String? = insertBefore.isEmpty ? nil : insertBefore
+                    onAdd(trimmed, before)
+                    dismiss()
+                }
+                .keyboardShortcut(.defaultAction)
+                .disabled(!isValid)
+            }
+        }
+        .padding(20)
+        .frame(width: 340)
     }
 }

--- a/Tusk/Views/Main/EnumDetailView.swift
+++ b/Tusk/Views/Main/EnumDetailView.swift
@@ -51,17 +51,11 @@ struct EnumDetailView: View {
                 enumName: enumName,
                 existingValues: values,
                 onAdd: { newValue, beforeValue in
-                    Task {
-                        do {
-                            let posClause = beforeValue.map { " BEFORE \(quoteLiteral($0))" } ?? ""
-                            let sql = "ALTER TYPE \(quoteIdentifier(schema)).\(quoteIdentifier(enumName)) ADD VALUE \(quoteLiteral(newValue))\(posClause);"
-                            _ = try await client.query(sql)
-                            try? await appState.refreshSchema(for: connection)
-                            await reload()
-                        } catch {
-                            actionError = error.localizedDescription
-                        }
-                    }
+                    let posClause = beforeValue.map { " BEFORE \(quoteLiteral($0))" } ?? ""
+                    let sql = "ALTER TYPE \(quoteIdentifier(schema)).\(quoteIdentifier(enumName)) ADD VALUE \(quoteLiteral(newValue))\(posClause);"
+                    _ = try await client.query(sql)
+                    try? await appState.refreshSchema(for: connection)
+                    await reload()
                 }
             )
         }
@@ -145,8 +139,14 @@ struct EnumDetailView: View {
             values = cached.values
         } else {
             if let all = try? await client.enums() {
-                values = all.first(where: { $0.schema == schema && $0.name == enumName })?.values ?? []
+                if let found = all.first(where: { $0.schema == schema && $0.name == enumName }) {
+                    values = found.values
+                } else {
+                    values = []
+                    loadFailed = true
+                }
             } else {
+                values = []
                 loadFailed = true
             }
         }
@@ -241,13 +241,15 @@ struct EnumDetailView: View {
 private struct AddEnumValueSheet: View {
     let enumName: String
     let existingValues: [String]
-    let onAdd: (String, String?) -> Void
+    let onAdd: (String, String?) async throws -> Void
 
     @Environment(\.dismiss) private var dismiss
     @AppStorage("tusk.content.fontSize") private var contentFontSize = 13.0
 
     @State private var newValue = ""
     @State private var insertBefore: String = ""   // empty string = append
+    @State private var isSubmitting = false
+    @State private var submitError: String? = nil
 
     private var isValid: Bool { !newValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
 
@@ -263,6 +265,7 @@ private struct AddEnumValueSheet: View {
                 TextField("new_value", text: $newValue)
                     .textFieldStyle(.roundedBorder)
                     .font(.system(size: contentFontSize, design: .monospaced))
+                    .disabled(isSubmitting)
             }
 
             VStack(alignment: .leading, spacing: 6) {
@@ -276,20 +279,37 @@ private struct AddEnumValueSheet: View {
                     }
                 }
                 .labelsHidden()
+                .disabled(isSubmitting)
+            }
+
+            if let submitError {
+                Text(submitError)
+                    .font(.system(size: contentFontSize - 1))
+                    .foregroundStyle(.red)
             }
 
             HStack {
                 Spacer()
                 Button("Cancel") { dismiss() }
                     .keyboardShortcut(.cancelAction)
+                    .disabled(isSubmitting)
                 Button("Add Value") {
                     let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
                     let before: String? = insertBefore.isEmpty ? nil : insertBefore
-                    onAdd(trimmed, before)
-                    dismiss()
+                    isSubmitting = true
+                    submitError = nil
+                    Task {
+                        do {
+                            try await onAdd(trimmed, before)
+                            dismiss()
+                        } catch {
+                            submitError = error.localizedDescription
+                            isSubmitting = false
+                        }
+                    }
                 }
                 .keyboardShortcut(.defaultAction)
-                .disabled(!isValid)
+                .disabled(!isValid || isSubmitting)
             }
         }
         .padding(20)

--- a/Tusk/Views/Main/FunctionDetailView.swift
+++ b/Tusk/Views/Main/FunctionDetailView.swift
@@ -36,9 +36,15 @@ struct FunctionDetailView: View {
                     sourcePane(detail: detail)
                 }
             } else {
-                Text("Failed to load function details.")
-                    .foregroundStyle(.secondary)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                ContentUnavailableView {
+                    Label("Failed to Load Function", systemImage: "exclamationmark.triangle")
+                } description: {
+                    Text("Could not retrieve details for this function.")
+                } actions: {
+                    Button("Retry") { Task { await reload() } }
+                        .buttonStyle(.bordered)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
         }
         .task { await reload() }
@@ -55,7 +61,7 @@ struct FunctionDetailView: View {
             Spacer()
             if let detail, !isLoading {
                 metadataBadges(detail: detail)
-                if !isReadOnly || detail.volatility != "VOLATILE" {
+                if !isReadOnly || detail.volatility == "IMMUTABLE" {
                     Toggle(isOn: $isExecutorVisible) {
                         Label("Run", systemImage: "play.fill")
                             .font(.callout)

--- a/Tusk/Views/Main/FunctionDetailView.swift
+++ b/Tusk/Views/Main/FunctionDetailView.swift
@@ -25,7 +25,8 @@ struct FunctionDetailView: View {
                 ProgressView()
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else if let detail {
-                if isExecutorVisible {
+                let canRun = !isReadOnly || detail.volatility == "IMMUTABLE"
+                if canRun && isExecutorVisible {
                     VSplitView {
                         sourcePane(detail: detail)
                             .frame(minHeight: 120)
@@ -48,6 +49,11 @@ struct FunctionDetailView: View {
             }
         }
         .task { await reload() }
+        .onChange(of: isReadOnly) {
+            if let detail, isReadOnly && detail.volatility != "IMMUTABLE" {
+                isExecutorVisible = false
+            }
+        }
     }
 
     // MARK: - Toolbar

--- a/Tusk/Views/Main/SequenceDetailView.swift
+++ b/Tusk/Views/Main/SequenceDetailView.swift
@@ -169,7 +169,9 @@ struct SequenceDetailView: View {
     // MARK: - Mutations
 
     private func setvalue() {
-        guard let newVal = Int64(setValueText) else { return }
+        guard let newVal = Int64(setValueText),
+              let detail,
+              newVal >= detail.minValue && newVal <= detail.maxValue else { return }
         Task {
             do {
                 let regclass = "\(quoteIdentifier(schema)).\(quoteIdentifier(sequenceName))".replacingOccurrences(of: "'", with: "''")

--- a/Tusk/Views/Main/SequenceDetailView.swift
+++ b/Tusk/Views/Main/SequenceDetailView.swift
@@ -124,6 +124,8 @@ struct SequenceDetailView: View {
                 .foregroundStyle(.secondary)
 
             // Set value
+            let parsedValue = Int64(setValueText)
+            let outOfRange = parsedValue.map { $0 < detail.minValue || $0 > detail.maxValue } ?? false
             VStack(alignment: .leading, spacing: 4) {
                 HStack(spacing: 8) {
                     TextField("New value…", text: $setValueText)
@@ -133,12 +135,9 @@ struct SequenceDetailView: View {
                     Button("Set Value") { setvalue() }
                         .buttonStyle(.bordered)
                         .controlSize(.small)
-                        .disabled({
-                            guard let v = Int64(setValueText) else { return true }
-                            return v < detail.minValue || v > detail.maxValue
-                        }())
+                        .disabled(parsedValue == nil || outOfRange)
                 }
-                if let v = Int64(setValueText), (v < detail.minValue || v > detail.maxValue) {
+                if outOfRange {
                     Text("Must be between \(detail.minValue) and \(detail.maxValue)")
                         .font(.system(size: contentFontSize - 2))
                         .foregroundStyle(.orange)

--- a/Tusk/Views/Main/SequenceDetailView.swift
+++ b/Tusk/Views/Main/SequenceDetailView.swift
@@ -38,9 +38,15 @@ struct SequenceDetailView: View {
                     .padding(16)
                 }
             } else {
-                Text("Failed to load sequence details.")
-                    .foregroundStyle(.secondary)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                ContentUnavailableView {
+                    Label("Failed to Load Sequence", systemImage: "exclamationmark.triangle")
+                } description: {
+                    Text("Could not retrieve details for \(schema).\(sequenceName).")
+                } actions: {
+                    Button("Retry") { Task { await reload() } }
+                        .buttonStyle(.bordered)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
         }
         .alert("Action Failed", isPresented: Binding(
@@ -58,7 +64,7 @@ struct SequenceDetailView: View {
 
     private var toolbar: some View {
         HStack(spacing: 10) {
-            Image(systemName: "arrow.clockwise")
+            Image(systemName: "list.number")
                 .foregroundStyle(.secondary)
             Text("\(schema).\(sequenceName)")
                 .font(.system(size: contentFontSize, weight: .semibold, design: contentFontDesign.design))
@@ -118,15 +124,25 @@ struct SequenceDetailView: View {
                 .foregroundStyle(.secondary)
 
             // Set value
-            HStack(spacing: 8) {
-                TextField("New value…", text: $setValueText)
-                    .textFieldStyle(.roundedBorder)
-                    .frame(width: 140)
-                    .font(.system(size: contentFontSize, design: contentFontDesign.design))
-                Button("Set Value") { setvalue() }
-                    .buttonStyle(.bordered)
-                    .controlSize(.small)
-                    .disabled(Int64(setValueText) == nil)
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 8) {
+                    TextField("New value…", text: $setValueText)
+                        .textFieldStyle(.roundedBorder)
+                        .frame(width: 140)
+                        .font(.system(size: contentFontSize, design: contentFontDesign.design))
+                    Button("Set Value") { setvalue() }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                        .disabled({
+                            guard let v = Int64(setValueText) else { return true }
+                            return v < detail.minValue || v > detail.maxValue
+                        }())
+                }
+                if let v = Int64(setValueText), (v < detail.minValue || v > detail.maxValue) {
+                    Text("Must be between \(detail.minValue) and \(detail.maxValue)")
+                        .font(.system(size: contentFontSize - 2))
+                        .foregroundStyle(.orange)
+                }
             }
 
             // Reset to 1


### PR DESCRIPTION
## Summary
- EnumDetailView: replace two-step NSAlert add-value flow with a single SwiftUI sheet (value name + position picker in one step); add per-row "Rename Value…" context menu; surface load errors with ContentUnavailableView + retry instead of a silent empty list
- SequenceDetailView: replace bare text error state with ContentUnavailableView + retry; fix duplicate `arrow.clockwise` toolbar icon (now `list.number`); validate Set Value input against sequence min/max with inline range hint
- FunctionDetailView: replace bare text error state with ContentUnavailableView + retry; tighten Run button visibility on read-only connections to IMMUTABLE-only (was `!= VOLATILE`, which incorrectly included STABLE)

## Issues
Closes #184, #185, #186, #187, #188, #189, #190, #191

## Test plan
- [ ] Enum detail — "Add Value…" opens a single sheet; position picker lists existing values; DB error shows inline error in sheet (stays open); success dismisses sheet and refreshes list
- [ ] Enum detail — right-click a value row → "Rename Value…" renames via `ALTER TYPE ... RENAME VALUE`; sidebar refreshes
- [ ] Enum detail — simulate a load failure (disconnect) → ContentUnavailableView with Retry appears; Retry re-fetches correctly
- [ ] Sequence detail — failed load shows ContentUnavailableView with Retry
- [ ] Sequence detail — leading toolbar icon is `list.number` (not `arrow.clockwise`)
- [ ] Sequence detail — Set Value: entering a value outside [minValue, maxValue] disables the button and shows orange range hint
- [ ] Function detail — failed load shows ContentUnavailableView with Retry
- [ ] Function detail — on a read-only connection, Run toggle only appears for IMMUTABLE functions, not STABLE or VOLATILE