### PR TITLE
ux: fix connection sheet, role detail badge, and copy

### DIFF
--- a/Tusk/Views/Main/RoleDetailView.swift
+++ b/Tusk/Views/Main/RoleDetailView.swift
@@ -77,7 +77,7 @@ struct RoleDetailView: View {
                 .foregroundStyle(.secondary)
             Text(roleName)
                 .font(.system(size: contentFontSize, weight: .semibold, design: contentFontDesign.design))
-            if isSuperuser {
+            if role?.superuser == true {
                 Text("superuser")
                     .font(.system(size: contentFontSize - 2, design: contentFontDesign.design))
                     .foregroundStyle(.secondary)
@@ -477,19 +477,31 @@ private struct ConnLimitEditor: View {
 
     @State private var editing = false
     @State private var text = ""
+    @State private var inputError: String? = nil
 
     var body: some View {
         if editing {
-            HStack(spacing: 4) {
-                TextField("", text: $text)
-                    .font(.system(size: fontSize, design: .monospaced))
-                    .frame(width: 60)
-                    .multilineTextAlignment(.trailing)
-                    .onSubmit { commit() }
-                Button("OK") { commit() }
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 4) {
+                    TextField("blank = unlimited", text: $text)
+                        .font(.system(size: fontSize, design: .monospaced))
+                        .frame(width: 80)
+                        .multilineTextAlignment(.trailing)
+                        .onSubmit { commit() }
+                        .onChange(of: text) { _, _ in inputError = nil }
+                    Button("OK") { commit() }
+                        .controlSize(.small)
+                    Button("Cancel") {
+                        editing = false
+                        inputError = nil
+                    }
                     .controlSize(.small)
-                Button("Cancel") { editing = false }
-                    .controlSize(.small)
+                }
+                if let inputError {
+                    Text(inputError)
+                        .font(.system(size: fontSize - 2))
+                        .foregroundStyle(.red)
+                }
             }
         } else {
             HStack(spacing: 4) {
@@ -506,8 +518,21 @@ private struct ConnLimitEditor: View {
     }
 
     private func commit() {
-        let v = Int(text.trimmingCharacters(in: .whitespaces)) ?? -1
+        let trimmed = text.trimmingCharacters(in: .whitespaces)
+        let v: Int
+        if trimmed.isEmpty {
+            v = -1
+        } else if let parsed = Int(trimmed), parsed >= -1 {
+            v = parsed
+        } else if let parsed = Int(trimmed), parsed < -1 {
+            inputError = "Must be ≥ 0, or blank for unlimited"
+            return
+        } else {
+            inputError = "Enter a whole number, or leave blank for unlimited"
+            return
+        }
         editing = false
+        inputError = nil
         Task { await onCommit(v) }
     }
 }

--- a/Tusk/Views/Main/RoleDetailView.swift
+++ b/Tusk/Views/Main/RoleDetailView.swift
@@ -522,11 +522,12 @@ private struct ConnLimitEditor: View {
         let v: Int
         if trimmed.isEmpty {
             v = -1
-        } else if let parsed = Int(trimmed), parsed >= -1 {
+        } else if let parsed = Int(trimmed) {
+            guard parsed >= -1 else {
+                inputError = "Must be 0 or higher (blank or -1 = unlimited)"
+                return
+            }
             v = parsed
-        } else if let parsed = Int(trimmed), parsed < -1 {
-            inputError = "Must be ≥ 0, or blank for unlimited"
-            return
         } else {
             inputError = "Enter a whole number, or leave blank for unlimited"
             return

--- a/Tusk/Views/Main/WelcomeView.swift
+++ b/Tusk/Views/Main/WelcomeView.swift
@@ -18,7 +18,7 @@ struct WelcomeView: View {
                     .font(.system(size: contentFontSize + 14, weight: .semibold, design: contentFontDesign.design))
 
                 VStack(spacing: 4) {
-                    Text("Native MacOS client for PostgreSQL.")
+                    Text("Native macOS client for PostgreSQL.")
                         .foregroundStyle(.secondary)
 
                     Text("Zero-telemetry. Privacy-focused.")

--- a/Tusk/Views/Sidebar/AddConnectionSheet.swift
+++ b/Tusk/Views/Sidebar/AddConnectionSheet.swift
@@ -56,6 +56,15 @@ struct AddConnectionSheet: View {
         return name.isEmpty || host.isEmpty || database.isEmpty || username.isEmpty
     }
 
+    /// A string that changes whenever any field that affects connectivity changes.
+    /// Used to clear the stale test result via a single .onChange modifier.
+    private var connectivityFingerprint: String {
+        [host, port, database, username, password,
+         useSSL ? "ssl" : "", verifySSLCertificate ? "verify" : "",
+         sshEnabled ? "ssh" : "", sshHost, sshPort, sshUser, sshKeyPath, sshPassphrase,
+         cloudSQLInstanceConnectionName, useADC ? "adc" : ""].joined(separator: "|")
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             // Header
@@ -261,15 +270,16 @@ struct AddConnectionSheet: View {
                     Button {
                         Task { await testConnection() }
                     } label: {
-                        if isTestingConnection {
-                            ProgressView().controlSize(.small)
-                        } else {
-                            Text("Test Connection")
+                        HStack(spacing: 6) {
+                            if isTestingConnection {
+                                ProgressView().controlSize(.mini)
+                            }
+                            Text(isTestingConnection ? "Testing…" : "Test Connection")
                         }
                     }
                     .disabled({
-                        if isCloudSQL { return cloudSQLInstanceConnectionName.isEmpty || database.isEmpty || username.isEmpty }
-                        return host.isEmpty || database.isEmpty || username.isEmpty
+                        if isCloudSQL { return isTestingConnection || cloudSQLInstanceConnectionName.isEmpty || database.isEmpty || username.isEmpty }
+                        return isTestingConnection || host.isEmpty || database.isEmpty || username.isEmpty
                     }())
 
                     Spacer()
@@ -285,6 +295,7 @@ struct AddConnectionSheet: View {
             .padding()
         }
         .frame(width: 480)
+        .onChange(of: connectivityFingerprint) { _, _ in testResult = nil }
         .onAppear {
             populate()
             gcloudAvailable = CloudSQLProxy.findBinary("gcloud") != nil

--- a/Tusk/Views/Sidebar/AddConnectionSheet.swift
+++ b/Tusk/Views/Sidebar/AddConnectionSheet.swift
@@ -59,7 +59,8 @@ struct AddConnectionSheet: View {
     /// A string that changes whenever any field that affects connectivity changes.
     /// Used to clear the stale test result via a single .onChange modifier.
     private var connectivityFingerprint: String {
-        [host, port, database, username, password,
+        [connectionType.rawValue,
+         host, port, database, username, password,
          useSSL ? "ssl" : "", useSSL && verifySSLCertificate ? "verify" : "",
          sshEnabled ? "ssh" : "", sshHost, sshPort, sshUser, sshKeyPath, sshPassphrase,
          cloudSQLInstanceConnectionName, useADC ? "adc" : ""].joined(separator: "|")
@@ -276,6 +277,7 @@ struct AddConnectionSheet: View {
                             }
                             Text(isTestingConnection ? "Testing…" : "Test Connection")
                         }
+                        .frame(minWidth: 120)
                     }
                     .disabled({
                         if isCloudSQL { return isTestingConnection || cloudSQLInstanceConnectionName.isEmpty || database.isEmpty || username.isEmpty }
@@ -472,19 +474,20 @@ struct AddConnectionSheet: View {
     }
 
     private func testConnection() async {
+        let startedFingerprint = connectivityFingerprint
         isTestingConnection = true
         testResult = nil
 
         if isCloudSQL {
-            await testCloudSQLConnection()
+            await testCloudSQLConnection(startedFingerprint: startedFingerprint)
         } else {
-            await testDirectConnection()
+            await testDirectConnection(startedFingerprint: startedFingerprint)
         }
 
         isTestingConnection = false
     }
 
-    private func testDirectConnection() async {
+    private func testDirectConnection(startedFingerprint: String) async {
         var info = Connection(
             name: name, host: host, port: Int(port) ?? 5432,
             database: database, username: username,
@@ -514,12 +517,12 @@ struct AddConnectionSheet: View {
             do {
                 try await client.connect(to: info, password: password)
                 await client.disconnect()
-                testResult = "✓ Connected successfully"
+                if connectivityFingerprint == startedFingerprint { testResult = "✓ Connected successfully" }
             } catch {
-                testResult = "✗ \(friendlyError(error))"
+                if connectivityFingerprint == startedFingerprint { testResult = "✗ \(friendlyError(error))" }
             }
         } catch {
-            testResult = "✗ \(friendlyError(error))"
+            if connectivityFingerprint == startedFingerprint { testResult = "✗ \(friendlyError(error))" }
         }
 
         if let tunnel { await tunnel.stop() }
@@ -568,7 +571,7 @@ struct AddConnectionSheet: View {
         }
     }
 
-    private func testCloudSQLConnection() async {
+    private func testCloudSQLConnection(startedFingerprint: String) async {
         let proxy = CloudSQLProxy()
         testProxy = proxy
         defer { testProxy = nil }
@@ -595,12 +598,12 @@ struct AddConnectionSheet: View {
             do {
                 try await client.connect(to: effectiveInfo, password: pw)
                 await client.disconnect()
-                testResult = "✓ Connected successfully"
+                if connectivityFingerprint == startedFingerprint { testResult = "✓ Connected successfully" }
             } catch {
-                testResult = "✗ \(friendlyError(error))"
+                if connectivityFingerprint == startedFingerprint { testResult = "✗ \(friendlyError(error))" }
             }
         } catch {
-            testResult = "✗ \(friendlyError(error))"
+            if connectivityFingerprint == startedFingerprint { testResult = "✗ \(friendlyError(error))" }
         }
         await proxy.stop()
     }

--- a/Tusk/Views/Sidebar/AddConnectionSheet.swift
+++ b/Tusk/Views/Sidebar/AddConnectionSheet.swift
@@ -60,7 +60,7 @@ struct AddConnectionSheet: View {
     /// Used to clear the stale test result via a single .onChange modifier.
     private var connectivityFingerprint: String {
         [host, port, database, username, password,
-         useSSL ? "ssl" : "", verifySSLCertificate ? "verify" : "",
+         useSSL ? "ssl" : "", useSSL && verifySSLCertificate ? "verify" : "",
          sshEnabled ? "ssh" : "", sshHost, sshPort, sshUser, sshKeyPath, sshPassphrase,
          cloudSQLInstanceConnectionName, useADC ? "adc" : ""].joined(separator: "|")
     }


### PR DESCRIPTION
## Summary
- AddConnectionSheet: keep "Test Connection" label visible during testing (spinner shown inline); clear stale test result whenever any connectivity field changes (host, port, DB, credentials, SSL, SSH, Cloud SQL)
- RoleDetailView: fix "superuser" toolbar badge to reflect the viewed role's own attribute, not the connected user's privilege; add input validation to ConnLimitEditor with inline error messages
- WelcomeView: fix "MacOS" → "macOS" in subtitle copy

## Issues
Closes #178, Closes #179, Closes #181, Closes #182, Closes #183

## Test plan
- [ ] "Test Connection" button shows spinner + "Testing…" label side-by-side while testing; width stays stable
- [ ] Editing host, port, database, username, password, SSL, SSH, or Cloud SQL fields clears the "✓ Connected" badge; editing name/notes/color does not
- [ ] ConnLimitEditor: blank input → saves as ∞; integer ≥ -1 → saves correctly; negative integer < -1 or non-integer → inline red error, field stays open
- [ ] "superuser" badge appears on superuser roles regardless of the connected user's privilege level; does not appear on non-superuser roles
- [ ] Welcome screen reads "Native macOS client for PostgreSQL."