### PR TITLE
perf: nine performance optimisations across SQL, sidebar, copy, and proxy

### DIFF
--- a/Tusk/AppState.swift
+++ b/Tusk/AppState.swift
@@ -267,24 +267,14 @@ final class AppState {
         try await connect(connection)
     }
 
-    /// Polls a running proxy until it crashes, then syncs the crash status into
-    /// proxyStatuses so the sidebar badge and "Restart Proxy" menu reflect reality.
+    /// Awaits proxy termination, then syncs the crash status into proxyStatuses
+    /// so the sidebar badge and "Restart Proxy" menu reflect reality.
     private func monitorProxy(_ proxy: CloudSQLProxy, connectionID: UUID) async {
-        while true {
-            try? await Task.sleep(nanoseconds: 1_000_000_000) // 1 s
-            let current = await proxy.status
-            // If the proxy is still alive or we've already recorded a crash, stop.
-            guard case .running = current else {
-                if case .crashed(let msg) = current {
-                    // Only update if we still own this proxy (user may have reconnected).
-                    if cloudProxies[connectionID] === proxy {
-                        proxyStatuses[connectionID] = .crashed(msg)
-                    }
-                }
-                return
-            }
-            // Keep monitoring while the proxy's own status says it's still running.
-            if cloudProxies[connectionID] !== proxy { return }
+        await proxy.waitForTermination()
+        // Only update if we still own this proxy (user may have reconnected).
+        guard cloudProxies[connectionID] === proxy else { return }
+        if case .crashed(let msg) = await proxy.status {
+            proxyStatuses[connectionID] = .crashed(msg)
         }
     }
 

--- a/Tusk/Database/CloudSQLProxy.swift
+++ b/Tusk/Database/CloudSQLProxy.swift
@@ -18,7 +18,7 @@ actor CloudSQLProxy {
     private(set) var logLines: [String] = []
 
     private var process: Process?
-    private var terminationContinuation: CheckedContinuation<Void, Never>?
+    private var terminationContinuations: [CheckedContinuation<Void, Never>] = []
 
     // MARK: - Start
 
@@ -112,8 +112,7 @@ actor CloudSQLProxy {
             if case .crashed = status {
                 cont.resume()
             } else {
-                precondition(terminationContinuation == nil, "waitForTermination() called concurrently — only one caller supported")
-                terminationContinuation = cont
+                terminationContinuations.append(cont)
             }
         }
     }
@@ -122,8 +121,8 @@ actor CloudSQLProxy {
         guard case .running = status else { return }
         let lastLog = logLines.last ?? "Proxy exited unexpectedly."
         status = .crashed(lastLog)
-        terminationContinuation?.resume()
-        terminationContinuation = nil
+        terminationContinuations.forEach { $0.resume() }
+        terminationContinuations = []
     }
 
     private func waitForPort(_ port: Int, timeout: TimeInterval) async throws {

--- a/Tusk/Database/CloudSQLProxy.swift
+++ b/Tusk/Database/CloudSQLProxy.swift
@@ -112,6 +112,7 @@ actor CloudSQLProxy {
             if case .crashed = status {
                 cont.resume()
             } else {
+                precondition(terminationContinuation == nil, "waitForTermination() called concurrently — only one caller supported")
                 terminationContinuation = cont
             }
         }

--- a/Tusk/Database/CloudSQLProxy.swift
+++ b/Tusk/Database/CloudSQLProxy.swift
@@ -18,6 +18,7 @@ actor CloudSQLProxy {
     private(set) var logLines: [String] = []
 
     private var process: Process?
+    private var terminationContinuation: CheckedContinuation<Void, Never>?
 
     // MARK: - Start
 
@@ -102,10 +103,26 @@ actor CloudSQLProxy {
         if logLines.count > 50 { logLines.removeFirst(logLines.count - 50) }
     }
 
+    /// Suspends until the proxy process terminates (crashes or is stopped externally).
+    /// Returns immediately if already crashed.
+    func waitForTermination() async {
+        if case .crashed = status { return }
+        await withCheckedContinuation { cont in
+            // Check again inside the closure to close the race between the guard above and here.
+            if case .crashed = status {
+                cont.resume()
+            } else {
+                terminationContinuation = cont
+            }
+        }
+    }
+
     private func handleTermination() {
         guard case .running = status else { return }
         let lastLog = logLines.last ?? "Proxy exited unexpectedly."
         status = .crashed(lastLog)
+        terminationContinuation?.resume()
+        terminationContinuation = nil
     }
 
     private func waitForPort(_ port: Int, timeout: TimeInterval) async throws {

--- a/Tusk/Database/DatabaseClient.swift
+++ b/Tusk/Database/DatabaseClient.swift
@@ -263,7 +263,7 @@ actor DatabaseClient {
     func tableDDL(schema: String, table: String) async throws -> String {
         let s = schema.sqlEscaped
         let t = table.sqlEscaped
-        let cols = try await query("""
+        async let colsFetch = query("""
             SELECT
                 a.attname,
                 pg_catalog.format_type(a.atttypid, a.atttypmod),
@@ -281,7 +281,7 @@ actor DatabaseClient {
             ORDER BY a.attnum
             """)
 
-        let cons = try await query("""
+        async let consFetch = query("""
             SELECT pg_catalog.pg_get_constraintdef(con.oid, true)
             FROM pg_catalog.pg_constraint con
             JOIN pg_catalog.pg_class c ON c.oid = con.conrelid
@@ -289,6 +289,8 @@ actor DatabaseClient {
             WHERE n.nspname = '\(s)' AND c.relname = '\(t)'
             ORDER BY con.contype
             """)
+
+        let (cols, cons) = try await (colsFetch, consFetch)
 
         var lines: [String] = []
         for row in cols.rows {

--- a/Tusk/Models/QueryResult.swift
+++ b/Tusk/Models/QueryResult.swift
@@ -273,20 +273,20 @@ struct ExplainResult: Sendable {
 
 // MARK: - Schema object models
 
-struct EnumInfo: Identifiable, Sendable {
+struct EnumInfo: Identifiable, Hashable, Sendable {
     var id: String { "\(schema).\(name)" }
     let schema: String
     let name: String
     let values: [String]
 }
 
-struct SequenceInfo: Identifiable, Sendable {
+struct SequenceInfo: Identifiable, Hashable, Sendable {
     var id: String { "\(schema).\(name)" }
     let schema: String
     let name: String
 }
 
-struct FunctionInfo: Identifiable, Sendable {
+struct FunctionInfo: Identifiable, Hashable, Sendable {
     var id: String { "\(schema).\(signature)" }
     let schema: String
     let name: String

--- a/Tusk/Models/QueryResult.swift
+++ b/Tusk/Models/QueryResult.swift
@@ -89,35 +89,51 @@ func exportResultAsCSV(_ result: QueryResult, defaultName: String) {
 // MARK: - Clipboard copy helpers
 
 /// Copies rows as CSV (header + data) to the system clipboard.
+/// The string is built off @MainActor; the pasteboard write happens on @MainActor via the completion.
 @MainActor
-func copyRowsAsCSV(columns: [QueryColumn], rows: [[QueryCell]]) {
-    let lines = csvLines(columns: columns, rows: rows)
-    NSPasteboard.general.clearContents()
-    NSPasteboard.general.setString(lines.joined(separator: "\n"), forType: .string)
+func copyRowsAsCSV(columns: [QueryColumn], rows: [[QueryCell]], completion: (@MainActor () -> Void)? = nil) {
+    let cols = columns, rs = rows
+    Task {
+        let text = await Task.detached(priority: .userInitiated) {
+            csvLines(columns: cols, rows: rs).joined(separator: "\n")
+        }.value
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(text, forType: .string)
+        completion?()
+    }
 }
 
 /// Copies rows as a JSON array of objects to the system clipboard.
 /// Values are serialized with native JSON types: null, number, bool, string.
+/// The JSON is built off @MainActor; the pasteboard write happens on @MainActor via the completion.
 @MainActor
-func copyRowsAsJSON(columns: [QueryColumn], rows: [[QueryCell]]) {
-    let objects: [[String: Any]] = rows.map { row in
-        var obj: [String: Any] = [:]
-        for (col, cell) in zip(columns, row) {
-            switch cell {
-            case .null:             obj[col.name] = NSNull()
-            case .integer(let i):  obj[col.name] = NSNumber(value: i)
-            case .double(let d):   obj[col.name] = NSNumber(value: d)
-            case .bool(let b):     obj[col.name] = b
-            case .text(let s):     obj[col.name] = s
-            case .bytes(let data): obj[col.name] = data.base64EncodedString()
+func copyRowsAsJSON(columns: [QueryColumn], rows: [[QueryCell]], completion: (@MainActor () -> Void)? = nil) {
+    let cols = columns, rs = rows
+    Task {
+        let text = await Task.detached(priority: .userInitiated) {
+            let objects: [[String: Any]] = rs.map { row in
+                var obj: [String: Any] = [:]
+                for (col, cell) in zip(cols, row) {
+                    switch cell {
+                    case .null:             obj[col.name] = NSNull()
+                    case .integer(let i):  obj[col.name] = NSNumber(value: i)
+                    case .double(let d):   obj[col.name] = NSNumber(value: d)
+                    case .bool(let b):     obj[col.name] = b
+                    case .text(let s):     obj[col.name] = s
+                    case .bytes(let data): obj[col.name] = data.base64EncodedString()
+                    }
+                }
+                return obj
             }
-        }
-        return obj
+            guard let data = try? JSONSerialization.data(withJSONObject: objects, options: [.prettyPrinted, .sortedKeys]),
+                  let str = String(data: data, encoding: .utf8) else { return "" }
+            return str
+        }.value
+        guard !text.isEmpty else { return }
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(text, forType: .string)
+        completion?()
     }
-    guard let data = try? JSONSerialization.data(withJSONObject: objects, options: [.prettyPrinted, .sortedKeys]),
-          let str = String(data: data, encoding: .utf8) else { return }
-    NSPasteboard.general.clearContents()
-    NSPasteboard.general.setString(str, forType: .string)
 }
 
 // MARK: - INSERT copy helpers
@@ -160,11 +176,18 @@ func copyRowAsInsert(schema: String, table: String, columns: [QueryColumn], row:
 }
 
 /// Copies all rows as PostgreSQL INSERT statements (one per line) to the clipboard.
+/// The SQL is built off @MainActor; the pasteboard write happens on @MainActor via the completion.
 @MainActor
-func copyRowsAsInsert(schema: String, table: String, columns: [QueryColumn], rows: [[QueryCell]]) {
-    let statements = rows.map { insertStatement(schema: schema, table: table, columns: columns, row: $0) }.joined(separator: "\n")
-    NSPasteboard.general.clearContents()
-    NSPasteboard.general.setString(statements, forType: .string)
+func copyRowsAsInsert(schema: String, table: String, columns: [QueryColumn], rows: [[QueryCell]], completion: (@MainActor () -> Void)? = nil) {
+    let s = schema, t = table, cols = columns, rs = rows
+    Task {
+        let text = await Task.detached(priority: .userInitiated) {
+            rs.map { insertStatement(schema: s, table: t, columns: cols, row: $0) }.joined(separator: "\n")
+        }.value
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(text, forType: .string)
+        completion?()
+    }
 }
 
 // MARK: - Multi-statement execution

--- a/Tusk/Views/Main/DataBrowserView.swift
+++ b/Tusk/Views/Main/DataBrowserView.swift
@@ -299,7 +299,7 @@ struct DataBrowserView: View {
 
         if !state.filterText.isEmpty {
             if let col = state.filterColumn {
-                sql += " WHERE \(quoteIdentifier(col)) ILIKE '%\(state.filterText.replacingOccurrences(of: "'", with: "''"))%'"
+                sql += " WHERE \(quoteIdentifier(col))::text ILIKE '%\(state.filterText.replacingOccurrences(of: "'", with: "''"))%'"
             } else {
                 sql += " WHERE \"\(tableName)\"::text ILIKE '%\(state.filterText.replacingOccurrences(of: "'", with: "''"))%'"
             }

--- a/Tusk/Views/Main/DataBrowserView.swift
+++ b/Tusk/Views/Main/DataBrowserView.swift
@@ -10,6 +10,7 @@ final class DataBrowserState {
     var error: String? = nil
     var offset: Int = 0
     var filterText: String = ""
+    var filterColumn: String? = nil
     var loadTask: Task<Void, Never>? = nil
     var filterDebounceTask: Task<Void, Never>? = nil
 }
@@ -99,6 +100,7 @@ struct DataBrowserView: View {
         .task { if state.result == nil { triggerLoad() } }
         .onChange(of: schemaName + "." + tableName) { _, _ in
             state.offset = 0
+            state.filterColumn = nil
             sortColumn = nil
             sortAscending = true
             triggerLoad()
@@ -130,8 +132,25 @@ struct DataBrowserView: View {
 
             Spacer()
 
+            Picker("Column", selection: $state.filterColumn) {
+                Text("All columns").tag(nil as String?)
+                ForEach(columns, id: \.name) { col in
+                    Text(col.name).tag(col.name as String?)
+                }
+            }
+            .pickerStyle(.menu)
+            .labelsHidden()
+            .frame(width: 110)
+            .help("Filter on a specific column, or all columns")
+            .onChange(of: state.filterColumn) { _, _ in
+                guard !state.filterText.isEmpty else { return }
+                state.offset = 0
+                triggerLoad()
+            }
+
             ZStack(alignment: .trailing) {
-                TextField("Filter…", text: $state.filterText)
+                TextField(state.filterColumn == nil ? "Filter all columns…" : "Filter \(state.filterColumn!)…",
+                          text: $state.filterText)
                     .textFieldStyle(.roundedBorder)
                     .frame(width: 180)
                 if state.isLoading && !state.filterText.isEmpty {
@@ -209,10 +228,11 @@ struct DataBrowserView: View {
 
             if !isView && !isReadOnly {
                 Button {
-                    copyRowsAsInsert(schema: schemaName, table: tableName, columns: result.columns, rows: result.rows)
-                    copiedInsert = true
-                    copiedInsertTask?.cancel()
-                    copiedInsertTask = Task { try? await Task.sleep(for: .milliseconds(1500)); if !Task.isCancelled { copiedInsert = false } }
+                    copyRowsAsInsert(schema: schemaName, table: tableName, columns: result.columns, rows: result.rows) {
+                        copiedInsert = true
+                        copiedInsertTask?.cancel()
+                        copiedInsertTask = Task { try? await Task.sleep(for: .milliseconds(1500)); if !Task.isCancelled { copiedInsert = false } }
+                    }
                 } label: {
                     Label(copiedInsert ? "Copied!" : "Copy INSERT",
                           systemImage: copiedInsert ? "checkmark" : "doc.on.clipboard")
@@ -222,10 +242,11 @@ struct DataBrowserView: View {
                 .help("Copy all rows as INSERT statements")
             }
             Button {
-                copyRowsAsCSV(columns: result.columns, rows: result.rows)
-                copiedCSV = true
-                copiedCSVTask?.cancel()
-                copiedCSVTask = Task { try? await Task.sleep(for: .milliseconds(1500)); if !Task.isCancelled { copiedCSV = false } }
+                copyRowsAsCSV(columns: result.columns, rows: result.rows) {
+                    copiedCSV = true
+                    copiedCSVTask?.cancel()
+                    copiedCSVTask = Task { try? await Task.sleep(for: .milliseconds(1500)); if !Task.isCancelled { copiedCSV = false } }
+                }
             } label: {
                 Label(copiedCSV ? "Copied!" : "Copy CSV",
                       systemImage: copiedCSV ? "checkmark" : "doc.on.clipboard")
@@ -234,10 +255,11 @@ struct DataBrowserView: View {
             .buttonStyle(.borderless)
             .help("Copy all rows as CSV")
             Button {
-                copyRowsAsJSON(columns: result.columns, rows: result.rows)
-                copiedJSON = true
-                copiedJSONTask?.cancel()
-                copiedJSONTask = Task { try? await Task.sleep(for: .milliseconds(1500)); if !Task.isCancelled { copiedJSON = false } }
+                copyRowsAsJSON(columns: result.columns, rows: result.rows) {
+                    copiedJSON = true
+                    copiedJSONTask?.cancel()
+                    copiedJSONTask = Task { try? await Task.sleep(for: .milliseconds(1500)); if !Task.isCancelled { copiedJSON = false } }
+                }
             } label: {
                 Label(copiedJSON ? "Copied!" : "Copy JSON",
                       systemImage: copiedJSON ? "checkmark" : "doc.on.clipboard")
@@ -276,7 +298,11 @@ struct DataBrowserView: View {
         var sql = "SELECT * FROM \(qualifiedName)"
 
         if !state.filterText.isEmpty {
-            sql += " WHERE \"\(tableName)\"::text ILIKE '%\(state.filterText)%'"
+            if let col = state.filterColumn {
+                sql += " WHERE \(quoteIdentifier(col)) ILIKE '%\(state.filterText.replacingOccurrences(of: "'", with: "''"))%'"
+            } else {
+                sql += " WHERE \"\(tableName)\"::text ILIKE '%\(state.filterText.replacingOccurrences(of: "'", with: "''"))%'"
+            }
         }
 
         if let col = sortColumn {

--- a/Tusk/Views/Main/QueryEditorView.swift
+++ b/Tusk/Views/Main/QueryEditorView.swift
@@ -389,10 +389,11 @@ struct QueryEditorView: View {
                 Spacer()
                 if !result.rows.isEmpty {
                     Button {
-                        copyRowsAsCSV(columns: result.columns, rows: result.rows)
-                        copiedCSV = true
                         copiedCSVTask?.cancel()
-                        copiedCSVTask = Task { try? await Task.sleep(for: .milliseconds(1500)); if !Task.isCancelled { copiedCSV = false } }
+                        copyRowsAsCSV(columns: result.columns, rows: result.rows) {
+                            copiedCSV = true
+                            copiedCSVTask = Task { try? await Task.sleep(for: .milliseconds(1500)); if !Task.isCancelled { copiedCSV = false } }
+                        }
                     } label: {
                         Label(copiedCSV ? "Copied!" : "Copy CSV",
                               systemImage: copiedCSV ? "checkmark" : "doc.on.clipboard").font(.caption)
@@ -400,10 +401,11 @@ struct QueryEditorView: View {
                     .buttonStyle(.borderless).controlSize(.small)
                     .help("Copy all rows as CSV")
                     Button {
-                        copyRowsAsJSON(columns: result.columns, rows: result.rows)
-                        copiedJSON = true
                         copiedJSONTask?.cancel()
-                        copiedJSONTask = Task { try? await Task.sleep(for: .milliseconds(1500)); if !Task.isCancelled { copiedJSON = false } }
+                        copyRowsAsJSON(columns: result.columns, rows: result.rows) {
+                            copiedJSON = true
+                            copiedJSONTask = Task { try? await Task.sleep(for: .milliseconds(1500)); if !Task.isCancelled { copiedJSON = false } }
+                        }
                     } label: {
                         Label(copiedJSON ? "Copied!" : "Copy JSON",
                               systemImage: copiedJSON ? "checkmark" : "doc.on.clipboard").font(.caption)

--- a/Tusk/Views/Main/QueryEditorView.swift
+++ b/Tusk/Views/Main/QueryEditorView.swift
@@ -43,22 +43,24 @@ struct QueryEditorView: View {
             if let index = appState.queryTabs.firstIndex(where: { $0.id == tab.id }) {
                 appState.queryTabs[index].sql = newValue
             }
-            // Debounced auto-save to disk (500 ms)
-            guard tab.sourceURL != nil else { return }
+            // Debounced auto-save to disk (500 ms) — file write runs off @MainActor
+            guard let saveURL = tab.sourceURL else { return }
             autoSaveTask?.cancel()
-            autoSaveTask = Task {
+            autoSaveTask = Task.detached(priority: .utility) {
                 try? await Task.sleep(for: .milliseconds(500))
-                guard !Task.isCancelled, let url = tab.sourceURL else { return }
+                guard !Task.isCancelled else { return }
                 do {
-                    try newValue.write(to: url, atomically: true, encoding: .utf8)
+                    try newValue.write(to: saveURL, atomically: true, encoding: .utf8)
                 } catch {
                     return
                 }
-                savedIndicatorTask?.cancel()
-                savedIndicatorTask = Task {
-                    savedIndicator = true
-                    try? await Task.sleep(for: .seconds(2))
-                    if !Task.isCancelled { savedIndicator = false }
+                await MainActor.run {
+                    savedIndicatorTask?.cancel()
+                    savedIndicatorTask = Task {
+                        savedIndicator = true
+                        try? await Task.sleep(for: .seconds(2))
+                        if !Task.isCancelled { savedIndicator = false }
+                    }
                 }
             }
         }
@@ -507,7 +509,6 @@ struct QueryEditorView: View {
                 executions[entryIndex].outcome = .error(error.localizedDescription)
                 break
             }
-            persistResultStateToTab()
         }
 
         isRunning = false
@@ -1628,19 +1629,11 @@ struct CellDetailView: View {
     let columnDataType: String
     @Environment(\.dismiss) private var dismiss
     @State private var showTree = true
+    @State private var cachedPrettyJSON: String? = nil
 
     private var parsedJSON: JSONValue? {
         guard columnDataType == "json" || columnDataType == "jsonb" else { return nil }
         return parseJSONValue(value)
-    }
-
-    private var prettyJSON: String {
-        guard let data = value.data(using: .utf8),
-              let obj = try? JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed),
-              let pretty = try? JSONSerialization.data(withJSONObject: obj, options: [.prettyPrinted, .sortedKeys]),
-              let str = String(data: pretty, encoding: .utf8)
-        else { return value }
-        return str
     }
 
     var body: some View {
@@ -1682,7 +1675,7 @@ struct CellDetailView: View {
             if let j = json, showTree {
                 JSONTreeView(value: j)
             } else {
-                let displayText = json != nil ? prettyJSON : value
+                let displayText = json != nil ? (cachedPrettyJSON ?? value) : value
                 ScrollView([.horizontal, .vertical]) {
                     if displayText.isEmpty {
                         Text("''")
@@ -1703,6 +1696,15 @@ struct CellDetailView: View {
             }
         }
         .frame(minWidth: 480, minHeight: 300)
+        .onAppear {
+            guard columnDataType == "json" || columnDataType == "jsonb" else { return }
+            guard let data = value.data(using: .utf8),
+                  let obj = try? JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed),
+                  let pretty = try? JSONSerialization.data(withJSONObject: obj, options: [.prettyPrinted, .sortedKeys]),
+                  let str = String(data: pretty, encoding: .utf8)
+            else { return }
+            cachedPrettyJSON = str
+        }
     }
 }
 

--- a/Tusk/Views/Main/SQLHighlighter.swift
+++ b/Tusk/Views/Main/SQLHighlighter.swift
@@ -116,8 +116,12 @@ enum SQLHighlighter {
         //    Line comments are always single-line, so the paragraph range is sufficient.
         //    Block comments use the full document range so multi-paragraph spans are caught.
         colorMatches(of: lineCommentRE, in: text, range: range, color: commentColour, to: textStorage, excluding: stringRanges)
-        let blockStringRanges = range == fullRange ? stringRanges : collectRanges(of: stringRE, in: text, range: fullRange)
-        colorMatches(of: blockCommentRE, in: text, range: fullRange, color: commentColour, to: textStorage, excluding: blockStringRanges)
+        // Block comments require whole-document context — only run on full-document passes.
+        // Paragraph-mode calls (from highlightEdited) only reach here when no /* or */ exists,
+        // so this pass would match nothing anyway; skip it to avoid an O(doc_size) scan.
+        if range == fullRange {
+            colorMatches(of: blockCommentRE, in: text, range: fullRange, color: commentColour, to: textStorage, excluding: stringRanges)
+        }
     }
 
     // MARK: - Helpers

--- a/Tusk/Views/Main/SQLHighlighter.swift
+++ b/Tusk/Views/Main/SQLHighlighter.swift
@@ -72,13 +72,18 @@ enum SQLHighlighter {
         guard !text.isEmpty else { return }
         let fullRange = NSRange(location: 0, length: text.utf16.count)
 
-        // Fall back to full-document pass when block comments are present — they can span
-        // multiple paragraphs and require whole-document context to highlight correctly.
+        // Fall back to full-document pass when block comments or multi-paragraph string literals
+        // may be present — both require whole-document context to highlight correctly.
+        // Odd single-quote count in the paragraph signals an unterminated string that started
+        // in a prior paragraph (or continues into the next), so full context is needed.
+        let paragraphRange = (text as NSString).paragraphRange(for: editedRange)
+        let paragraphText  = (text as NSString).substring(with: paragraphRange)
+        let quoteCount     = paragraphText.filter { $0 == "'" }.count
         let highlightRange: NSRange
-        if text.contains("/*") || text.contains("*/") {
+        if text.contains("/*") || text.contains("*/") || quoteCount % 2 != 0 {
             highlightRange = fullRange
         } else {
-            highlightRange = (text as NSString).paragraphRange(for: editedRange)
+            highlightRange = paragraphRange
         }
 
         applyHighlighting(to: textStorage, text: text, in: highlightRange, font: font)

--- a/Tusk/Views/Main/SQLHighlighter.swift
+++ b/Tusk/Views/Main/SQLHighlighter.swift
@@ -45,6 +45,8 @@ enum SQLHighlighter {
 
     // MARK: - Public API
 
+    /// Full-document highlight. Wraps in beginEditing/endEditing.
+    /// Use for programmatic text replacement (tab switch, font change, initial load).
     static func highlight(_ textStorage: NSTextStorage, font: NSFont) {
         let text = textStorage.string
         let fullRange = NSRange(location: 0, length: text.utf16.count)
@@ -55,35 +57,67 @@ enum SQLHighlighter {
         textStorage.beginEditing()
 
         if !text.isEmpty {
-        // 1. Reset everything to base style
-        textStorage.setAttributes([.font: font, .foregroundColor: NSColor.labelColor], range: fullRange)
+            applyHighlighting(to: textStorage, text: text, in: fullRange, font: font)
+        }
+
+        textStorage.endEditing()
+    }
+
+    /// Incremental highlight called from NSTextStorageDelegate.textStorage(_:willProcessEditing:range:changeInLength:).
+    /// Must NOT call beginEditing/endEditing — the text storage is already inside an editing session.
+    /// Highlights only the affected paragraph(s), falling back to a full-document pass when
+    /// the document contains block comment delimiters (/* or */).
+    static func highlightEdited(_ textStorage: NSTextStorage, editedRange: NSRange, font: NSFont) {
+        let text = textStorage.string
+        guard !text.isEmpty else { return }
+        let fullRange = NSRange(location: 0, length: text.utf16.count)
+
+        // Fall back to full-document pass when block comments are present — they can span
+        // multiple paragraphs and require whole-document context to highlight correctly.
+        let highlightRange: NSRange
+        if text.contains("/*") || text.contains("*/") {
+            highlightRange = fullRange
+        } else {
+            highlightRange = (text as NSString).paragraphRange(for: editedRange)
+        }
+
+        applyHighlighting(to: textStorage, text: text, in: highlightRange, font: font)
+    }
+
+    // MARK: - Internal
+
+    /// Applies syntax highlighting to `range` without begin/endEditing guards.
+    private static func applyHighlighting(to textStorage: NSTextStorage, text: String, in range: NSRange, font: NSFont) {
+        let fullRange = NSRange(location: 0, length: text.utf16.count)
+
+        // 1. Reset the target range to base style
+        textStorage.setAttributes([.font: font, .foregroundColor: NSColor.labelColor], range: range)
 
         // 2. Keywords — lowest priority, overwritten by string / comment passes
-        identRE.enumerateMatches(in: text, range: fullRange) { match, _, _ in
-            guard let range = match?.range else { return }
-            let word = (text as NSString).substring(with: range).uppercased()
+        identRE.enumerateMatches(in: text, range: range) { match, _, _ in
+            guard let r = match?.range else { return }
+            let word = (text as NSString).substring(with: r).uppercased()
             if keywords.contains(word) {
-                textStorage.addAttribute(.foregroundColor, value: keywordColour, range: range)
+                textStorage.addAttribute(.foregroundColor, value: keywordColour, range: r)
             }
         }
 
         // 3. Numbers
-        colorMatches(of: numberRE, in: text, range: fullRange, color: numberColour, to: textStorage)
+        colorMatches(of: numberRE, in: text, range: range, color: numberColour, to: textStorage)
 
-        // 4. Collect string literal ranges first; apply their colour and use them
-        //    to shield string contents from the comment passes below.
-        let stringRanges = collectRanges(of: stringRE, in: text, range: fullRange)
+        // 4. Collect string literal ranges (scoped to the highlight range) first; apply their
+        //    colour and use them to shield string contents from the comment passes below.
+        let stringRanges = collectRanges(of: stringRE, in: text, range: range)
         for r in stringRanges {
             textStorage.addAttribute(.foregroundColor, value: stringColour, range: r)
         }
 
-        // 5. Comments — highest priority, but must not fire inside string literals
-        //    (e.g. `'hello -- world'` should stay orange, not turn gray).
-        colorMatches(of: lineCommentRE,  in: text, range: fullRange, color: commentColour, to: textStorage, excluding: stringRanges)
-        colorMatches(of: blockCommentRE, in: text, range: fullRange, color: commentColour, to: textStorage, excluding: stringRanges)
-        } // end if !text.isEmpty
-
-        textStorage.endEditing()
+        // 5. Comments — highest priority, but must not fire inside string literals.
+        //    Line comments are always single-line, so the paragraph range is sufficient.
+        //    Block comments use the full document range so multi-paragraph spans are caught.
+        colorMatches(of: lineCommentRE, in: text, range: range, color: commentColour, to: textStorage, excluding: stringRanges)
+        let blockStringRanges = range == fullRange ? stringRanges : collectRanges(of: stringRE, in: text, range: fullRange)
+        colorMatches(of: blockCommentRE, in: text, range: fullRange, color: commentColour, to: textStorage, excluding: blockStringRanges)
     }
 
     // MARK: - Helpers

--- a/Tusk/Views/Main/SQLTextEditor.swift
+++ b/Tusk/Views/Main/SQLTextEditor.swift
@@ -49,8 +49,11 @@ struct SQLTextEditor: NSViewRepresentable {
         scrollView.drawsBackground = true
 
         if !text.isEmpty, let storage = textView.textStorage {
+            storage.delegate = context.coordinator
             textView.string = text
             SQLHighlighter.highlight(storage, font: editorFont)
+        } else {
+            textView.textStorage?.delegate = context.coordinator
         }
         textView.typingAttributes = baseTypingAttributes
 
@@ -81,23 +84,38 @@ struct SQLTextEditor: NSViewRepresentable {
     // MARK: - Coordinator
 
     @MainActor
-    final class Coordinator: NSObject, NSTextViewDelegate {
+    final class Coordinator: NSObject, NSTextViewDelegate, @preconcurrency NSTextStorageDelegate {
         var parent: SQLTextEditor
 
         init(_ parent: SQLTextEditor) { self.parent = parent }
 
+        // MARK: - NSTextStorageDelegate
+
+        /// Called from within the text storage editing session (inside endEditing).
+        /// Must NOT call beginEditing/endEditing — use incremental highlight path only.
+        /// AppKit always calls this on the main thread; @MainActor isolation is safe.
+        func textStorage(
+            _ textStorage: NSTextStorage,
+            willProcessEditing editedMask: NSTextStorageEditActions,
+            range editedRange: NSRange,
+            changeInLength delta: Int
+        ) {
+            // Only re-highlight when actual characters changed, not attribute-only updates
+            // (attribute-only updates come from the highlighter itself — guard prevents re-entry).
+            guard editedMask.contains(.editedCharacters) else { return }
+            SQLHighlighter.highlightEdited(textStorage, editedRange: editedRange, font: parent.editorFont)
+        }
+
+        // MARK: - NSTextViewDelegate
+
         func textDidChange(_ notification: Notification) {
-            guard let textView = notification.object as? NSTextView,
-                  let storage = textView.textStorage else { return }
+            guard let textView = notification.object as? NSTextView else { return }
             // Push text change to binding
             parent.text = textView.string
-            // Re-apply highlighting, preserving caret position
-            let sel = textView.selectedRange()
-            SQLHighlighter.highlight(storage, font: parent.editorFont)
-            // Always restore base typing attributes so the next inserted
-            // character never inherits stale colour from a deleted token.
+            // Restore base typing attributes so the next inserted character never
+            // inherits stale colour from a deleted token. Highlighting was already
+            // applied by the NSTextStorageDelegate callback above.
             textView.typingAttributes = parent.baseTypingAttributes
-            textView.setSelectedRange(sel)
         }
 
         @objc func selectionDidChange(_ notification: Notification) {

--- a/Tusk/Views/Sidebar/SidebarView.swift
+++ b/Tusk/Views/Sidebar/SidebarView.swift
@@ -122,9 +122,9 @@ private struct ConnectionSection: View {
 
     private typealias SchemaGroupEntry = (id: String, name: String, tables: [TableInfo], views: [TableInfo], enums: [EnumInfo], sequences: [SequenceInfo], functions: [FunctionInfo], onlyTables: Bool)
 
-    /// Cached result of the expensive grouping+sorting step. nil on first render;
-    /// populated by .task(id: schemaStamp) when schema data changes.
-    @State private var cachedGrouped: [SchemaGroupEntry]? = nil
+    /// Cached result of the expensive grouping+sorting step.
+    /// Populated by .onChange(of: schemaStamp, initial: true) — empty until first appear.
+    @State private var cachedGrouped: [SchemaGroupEntry] = []
 
     var isConnected: Bool { appState.isConnected(connection) }
 
@@ -133,9 +133,9 @@ private struct ConnectionSection: View {
     private var schemaStamp: Int {
         var hasher = Hasher()
         hasher.combine(appState.schemaTables[connection.id] ?? [])
-        hasher.combine((appState.schemaEnums[connection.id] ?? []).map(\.id))
-        hasher.combine((appState.schemaSequences[connection.id] ?? []).map(\.id))
-        hasher.combine((appState.schemaFunctions[connection.id] ?? []).map(\.id))
+        hasher.combine(appState.schemaEnums[connection.id] ?? [])
+        hasher.combine(appState.schemaSequences[connection.id] ?? [])
+        hasher.combine(appState.schemaFunctions[connection.id] ?? [])
         hasher.combine(Array(appState.schemaNamesCache[connection.id] ?? []).sorted())
         return hasher.finalize()
     }
@@ -184,7 +184,7 @@ private struct ConnectionSection: View {
     /// each schema's object arrays are narrowed and empty schemas are omitted.
     /// Uses cachedGrouped for the expensive grouping step; filtering is a cheap second pass.
     private var schemas: [SchemaGroupEntry] {
-        let grouped = cachedGrouped ?? computeGrouped()
+        let grouped = cachedGrouped
         let filter  = filterText.lowercased()
 
         func matches(_ name: String) -> Bool { filter.isEmpty || name.lowercased().contains(filter) }
@@ -230,7 +230,7 @@ private struct ConnectionSection: View {
         } header: {
             ConnectionHeader(connection: connection)
         }
-        .task(id: schemaStamp) {
+        .onChange(of: schemaStamp, initial: true) { _, _ in
             cachedGrouped = computeGrouped()
         }
     }

--- a/Tusk/Views/Sidebar/SidebarView.swift
+++ b/Tusk/Views/Sidebar/SidebarView.swift
@@ -120,20 +120,36 @@ private struct ConnectionSection: View {
     let connection: Connection
     var filterText: String = ""
 
+    private typealias SchemaGroupEntry = (id: String, name: String, tables: [TableInfo], views: [TableInfo], enums: [EnumInfo], sequences: [SequenceInfo], functions: [FunctionInfo], onlyTables: Bool)
+
+    /// Cached result of the expensive grouping+sorting step. nil on first render;
+    /// populated by .task(id: schemaStamp) when schema data changes.
+    @State private var cachedGrouped: [SchemaGroupEntry]? = nil
+
     var isConnected: Bool { appState.isConnected(connection) }
 
-    /// All schemas present in the cache, public first then alphabetical.
-    /// When `filterText` is non-empty, each schema's object arrays are narrowed to
-    /// names containing the filter string (case-insensitive), and schemas with no
-    /// matching objects are omitted entirely.
-    var schemas: [(id: String, name: String, tables: [TableInfo], views: [TableInfo], enums: [EnumInfo], sequences: [SequenceInfo], functions: [FunctionInfo], onlyTables: Bool)] {
-        let all       = appState.schemaTables[connection.id] ?? []
-        let allEnums  = appState.schemaEnums[connection.id] ?? []
-        let allSeqs   = appState.schemaSequences[connection.id] ?? []
-        let allFuncs  = appState.schemaFunctions[connection.id] ?? []
+    /// A hash of the connection-specific schema data. Changing this value tells
+    /// .task(id:) to recompute cachedGrouped without re-running on every AppState mutation.
+    private var schemaStamp: Int {
+        var hasher = Hasher()
+        hasher.combine(appState.schemaTables[connection.id] ?? [])
+        hasher.combine((appState.schemaEnums[connection.id] ?? []).map(\.id))
+        hasher.combine((appState.schemaSequences[connection.id] ?? []).map(\.id))
+        hasher.combine((appState.schemaFunctions[connection.id] ?? []).map(\.id))
+        hasher.combine(Array(appState.schemaNamesCache[connection.id] ?? []).sorted())
+        return hasher.finalize()
+    }
+
+    /// Builds the full grouped+sorted list without applying the filter.
+    /// This is the expensive step; results are cached in cachedGrouped.
+    private func computeGrouped() -> [SchemaGroupEntry] {
+        let all      = appState.schemaTables[connection.id] ?? []
+        let allEnums = appState.schemaEnums[connection.id] ?? []
+        let allSeqs  = appState.schemaSequences[connection.id] ?? []
+        let allFuncs = appState.schemaFunctions[connection.id] ?? []
         let allSchemas = Set(all.map { $0.schema })
             .union(allEnums.map { $0.schema })
-            .union(allSeqs.map { $0.schema })
+            .union(allSeqs.map  { $0.schema })
             .union(allFuncs.map { $0.schema })
             .union(appState.schemaNamesCache[connection.id] ?? [])
         let uniqueSchemas = allSchemas.sorted {
@@ -147,37 +163,41 @@ private struct ConnectionSection: View {
         let seqsBySchema   = Dictionary(grouping: allSeqs,  by: { $0.schema })
         let funcsBySchema  = Dictionary(grouping: allFuncs, by: { $0.schema })
 
-        let filter = filterText.lowercased()
-
-        func matches(_ name: String) -> Bool {
-            filter.isEmpty || name.lowercased().contains(filter)
-        }
-
-        // Include connection.id in the row ID so that identically-named schemas
-        // across different connections get distinct SwiftUI identities in the
-        // flattened List — otherwise @State (isExpanded) is shared between them.
-        let rows = uniqueSchemas.map { schema -> (id: String, name: String, tables: [TableInfo], views: [TableInfo], enums: [EnumInfo], sequences: [SequenceInfo], functions: [FunctionInfo], onlyTables: Bool) in
+        return uniqueSchemas.map { schema in
+            let tables = tablesBySchema[schema] ?? []
+            let views  = viewsBySchema[schema]  ?? []
+            let enums  = enumsBySchema[schema]  ?? []
+            let seqs   = seqsBySchema[schema]   ?? []
+            let funcs  = funcsBySchema[schema]  ?? []
             // onlyTables computed from unfiltered data so it doesn't flip when
             // a search filter removes views/enums/etc. from the result set.
-            let unfilteredTables = tablesBySchema[schema] ?? []
-            let unfilteredViews  = viewsBySchema[schema]  ?? []
-            let unfilteredEnums  = enumsBySchema[schema]  ?? []
-            let unfilteredSeqs   = seqsBySchema[schema]   ?? []
-            let unfilteredFuncs  = funcsBySchema[schema]  ?? []
-            let onlyTablesFlag   = !unfilteredTables.isEmpty &&
-                                   unfilteredViews.isEmpty &&
-                                   unfilteredEnums.isEmpty &&
-                                   unfilteredSeqs.isEmpty &&
-                                   unfilteredFuncs.isEmpty
+            let onlyTablesFlag = !tables.isEmpty && views.isEmpty && enums.isEmpty && seqs.isEmpty && funcs.isEmpty
             return (
-                id:        "\(connection.id)-\(schema)",
-                name:      schema,
-                tables:    unfilteredTables.filter { matches($0.name) },
-                views:     unfilteredViews.filter  { matches($0.name) },
-                enums:     unfilteredEnums.filter  { matches($0.name) },
-                sequences: unfilteredSeqs.filter   { matches($0.name) },
-                functions: unfilteredFuncs.filter  { matches($0.signature) },
+                id: "\(connection.id)-\(schema)", name: schema,
+                tables: tables, views: views, enums: enums, sequences: seqs, functions: funcs,
                 onlyTables: onlyTablesFlag
+            )
+        }
+    }
+
+    /// All schemas, public first then alphabetical. When `filterText` is non-empty,
+    /// each schema's object arrays are narrowed and empty schemas are omitted.
+    /// Uses cachedGrouped for the expensive grouping step; filtering is a cheap second pass.
+    private var schemas: [SchemaGroupEntry] {
+        let grouped = cachedGrouped ?? computeGrouped()
+        let filter  = filterText.lowercased()
+
+        func matches(_ name: String) -> Bool { filter.isEmpty || name.lowercased().contains(filter) }
+
+        let rows: [SchemaGroupEntry] = grouped.map { e in
+            (
+                id: e.id, name: e.name,
+                tables:    e.tables.filter    { matches($0.name) },
+                views:     e.views.filter     { matches($0.name) },
+                enums:     e.enums.filter     { matches($0.name) },
+                sequences: e.sequences.filter { matches($0.name) },
+                functions: e.functions.filter { matches($0.signature) },
+                onlyTables: e.onlyTables
             )
         }
 
@@ -209,6 +229,9 @@ private struct ConnectionSection: View {
             }
         } header: {
             ConnectionHeader(connection: connection)
+        }
+        .task(id: schemaStamp) {
+            cachedGrouped = computeGrouped()
         }
     }
 }


### PR DESCRIPTION
## Summary
- Replace full-document SQL re-highlighting on every keystroke with incremental paragraph-scoped highlighting; add block-comment fast-path guard (#168)
- Cache sidebar schema grouping with a hash stamp so the expensive sort/group pass only runs when data actually changes (#169)
- Fetch table columns and constraints in parallel with `async let` (#170)
- Add column-specific filtering to the data browser (#171)
- Run copy-to-clipboard (CSV/JSON/INSERT) on a background task so large result sets don't block the UI (#172)
- Replace the 1-second polling loop in `monitorProxy` with `waitForTermination()` using `CheckedContinuation` (#173)
- Remove redundant `persistResultStateToTab()` calls inside the per-statement loop (#174)
- Cache pretty-printed JSON in `CellDetailView` so it is computed once per open, not on every render (#175)
- Run query auto-save on a detached utility task; update the indicator via `MainActor.run` (#176)

## Issues
Closes #168, #169, #170, #171, #172, #173, #174, #175, #176

## Test plan
- Type a multi-line SQL query — keywords colour live with no flicker; `/* */` block comments highlight correctly
- Connect to a DB with multiple schemas — sidebar renders immediately on first appear with no blank flash
- Open a table detail view — columns and constraints load together (parallel fetch)
- Use the column picker in data browser — filter narrows to selected column; resets on table switch
- Copy a large result set as CSV/JSON/INSERT — UI stays responsive; paste confirms correct output
- Kill `cloud-sql-proxy` externally — app detects crash promptly without waiting for a poll cycle
- Run a multi-statement script — no UI stutter between statements
- Open a row with a large JSON value in cell detail — renders immediately, no frame drop on reopen
- Type in a query tab and pause — auto-save indicator fires without blocking typing