### PR TITLE
ux: data browser filter clear button and navigable relation nodes

### DIFF
--- a/Tusk/Database/DatabaseClient.swift
+++ b/Tusk/Database/DatabaseClient.swift
@@ -206,6 +206,7 @@ actor DatabaseClient {
             SELECT
                 tc.constraint_name,
                 kcu.column_name,
+                ccu.table_schema AS foreign_schema,
                 ccu.table_name  AS foreign_table,
                 ccu.column_name AS foreign_column
             FROM information_schema.table_constraints AS tc
@@ -222,8 +223,9 @@ actor DatabaseClient {
             ForeignKeyInfo(
                 constraintName: row[safe: 0]?.displayValue ?? "",
                 fromColumn:     row[safe: 1]?.displayValue ?? "",
-                toTable:        row[safe: 2]?.displayValue ?? "",
-                toColumn:       row[safe: 3]?.displayValue ?? ""
+                toSchema:       row[safe: 2]?.displayValue ?? "",
+                toTable:        row[safe: 3]?.displayValue ?? "",
+                toColumn:       row[safe: 4]?.displayValue ?? ""
             )
         }
     }

--- a/Tusk/Database/DatabaseClient.swift
+++ b/Tusk/Database/DatabaseClient.swift
@@ -213,7 +213,7 @@ actor DatabaseClient {
             JOIN information_schema.key_column_usage AS kcu
               ON tc.constraint_name = kcu.constraint_name AND tc.table_schema = kcu.table_schema
             JOIN information_schema.constraint_column_usage AS ccu
-              ON ccu.constraint_name = tc.constraint_name AND ccu.table_schema = tc.table_schema
+              ON ccu.constraint_name = tc.constraint_name AND ccu.constraint_schema = tc.constraint_schema
             WHERE tc.constraint_type = 'FOREIGN KEY'
               AND tc.table_schema = '\(s)'
               AND tc.table_name   = '\(t)'
@@ -244,7 +244,7 @@ actor DatabaseClient {
             JOIN information_schema.key_column_usage AS kcu
               ON tc.constraint_name = kcu.constraint_name AND tc.table_schema = kcu.table_schema
             JOIN information_schema.constraint_column_usage AS ccu
-              ON ccu.constraint_name = tc.constraint_name AND ccu.table_schema = tc.table_schema
+              ON ccu.constraint_name = tc.constraint_name AND ccu.constraint_schema = tc.constraint_schema
             WHERE tc.constraint_type = 'FOREIGN KEY'
               AND ccu.table_schema = '\(s)'
               AND ccu.table_name   = '\(t)'

--- a/Tusk/Models/Connection.swift
+++ b/Tusk/Models/Connection.swift
@@ -143,6 +143,7 @@ struct ForeignKeyInfo: Identifiable, Sendable {
     var id: String { constraintName }
     let constraintName: String
     let fromColumn: String
+    let toSchema: String
     let toTable: String
     let toColumn: String
 }

--- a/Tusk/Views/Main/DataBrowserView.swift
+++ b/Tusk/Views/Main/DataBrowserView.swift
@@ -157,6 +157,15 @@ struct DataBrowserView: View {
                     ProgressView()
                         .controlSize(.mini)
                         .padding(.trailing, 6)
+                } else if !state.filterText.isEmpty {
+                    Button {
+                        state.filterText = ""
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundStyle(.tertiary)
+                    }
+                    .buttonStyle(.plain)
+                    .padding(.trailing, 6)
                 }
             }
             .frame(width: 180)

--- a/Tusk/Views/Main/RelationsView.swift
+++ b/Tusk/Views/Main/RelationsView.swift
@@ -38,7 +38,7 @@ struct RelationsView: View {
     // MARK: - Edge model
 
     struct Edge: Identifiable {
-        var id: String { "\(isOutgoing ? "out" : "in"):\(relatedTable):\(label)" }
+        var id: String { "\(isOutgoing ? "out" : "in"):\(relatedSchema).\(relatedTable):\(label)" }
         let relatedSchema: String
         let relatedTable: String
         let label: String       // "fromCol → toCol"
@@ -130,6 +130,7 @@ struct RelationsView: View {
                 ForEach(Array(edges.enumerated()), id: \.element.id) { i, edge in
                     relatedNodeView(edge)
                         .position(positions[i])
+                        .onDisappear { NSCursor.pop() }
                 }
 
                 // Focal (center) node — on top

--- a/Tusk/Views/Main/RelationsView.swift
+++ b/Tusk/Views/Main/RelationsView.swift
@@ -4,8 +4,11 @@ import SwiftUI
 
 struct RelationsView: View {
     let client: DatabaseClient
+    let connectionID: UUID
     let schemaName: String
     let tableName: String
+
+    @Environment(AppState.self) private var appState
 
     @AppStorage("tusk.content.fontSize")   private var contentFontSize   = 13.0
     @AppStorage("tusk.content.fontDesign") private var contentFontDesign: TuskFontDesign = .sansSerif
@@ -230,6 +233,19 @@ struct RelationsView: View {
                 RoundedRectangle(cornerRadius: 8)
                     .stroke(borderColor.opacity(0.7), lineWidth: 1.5)
             )
+            .onHover { inside in
+                if inside { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+            }
+            .onTapGesture {
+                // Resolve schema: look up the table in schemaTables; fall back to the focal table's schema.
+                let resolvedSchema = appState.schemaTables[connectionID]?
+                    .first(where: { $0.name == edge.relatedTable })?.schema ?? schemaName
+                appState.openOrActivateTableTab(
+                    connectionID: connectionID,
+                    schema: resolvedSchema,
+                    tableName: edge.relatedTable
+                )
+            }
     }
 
     private func edgeLabelView(_ text: String, isOutgoing: Bool) -> some View {

--- a/Tusk/Views/Main/RelationsView.swift
+++ b/Tusk/Views/Main/RelationsView.swift
@@ -39,6 +39,7 @@ struct RelationsView: View {
 
     struct Edge: Identifiable {
         var id: String { "\(isOutgoing ? "out" : "in"):\(relatedTable):\(label)" }
+        let relatedSchema: String
         let relatedTable: String
         let label: String       // "fromCol → toCol"
         let isOutgoing: Bool    // true = arrow points away from focal node
@@ -46,12 +47,14 @@ struct RelationsView: View {
 
     var edges: [Edge] {
         let out = outgoing.map {
-            Edge(relatedTable: $0.toTable,
+            Edge(relatedSchema: $0.toSchema,
+                 relatedTable: $0.toTable,
                  label: "\($0.fromColumn) → \($0.toColumn)",
                  isOutgoing: true)
         }
         let inc = incoming.map {
-            Edge(relatedTable: $0.fromTable,
+            Edge(relatedSchema: $0.fromSchema,
+                 relatedTable: $0.fromTable,
                  label: "\($0.fromColumn) → \($0.toColumn)",
                  isOutgoing: false)
         }
@@ -237,12 +240,9 @@ struct RelationsView: View {
                 if inside { NSCursor.pointingHand.push() } else { NSCursor.pop() }
             }
             .onTapGesture {
-                // Resolve schema: look up the table in schemaTables; fall back to the focal table's schema.
-                let resolvedSchema = appState.schemaTables[connectionID]?
-                    .first(where: { $0.name == edge.relatedTable })?.schema ?? schemaName
                 appState.openOrActivateTableTab(
                     connectionID: connectionID,
-                    schema: resolvedSchema,
+                    schema: edge.relatedSchema,
                     tableName: edge.relatedTable
                 )
             }

--- a/Tusk/Views/Main/TableDetailView.swift
+++ b/Tusk/Views/Main/TableDetailView.swift
@@ -149,7 +149,7 @@ struct TableDetailView: View {
         case .keys:
             keysTab
         case .relations:
-            RelationsView(client: client, schemaName: schemaName, tableName: tableName)
+            RelationsView(client: client, connectionID: connectionID, schemaName: schemaName, tableName: tableName)
         case .indexes:
             indexesTab
         case .triggers:


### PR DESCRIPTION
## Summary
- Add an `xmark.circle.fill` clear button to the data browser filter field — appears when text is non-empty and no query is in flight, matching the sidebar filter pattern (#180)
- Make related table nodes in the Relations diagram tappable — single tap opens the table's detail tab via `openOrActivateTableTab`, pointer cursor on hover; cross-schema FK targets resolved correctly via `toSchema`/`fromSchema` from the FK query (#177)
- Fix `ForeignKeyInfo` to include `toSchema` (previously missing from the SQL query) so cross-schema foreign key navigation works correctly

## Issues
Closes #180, #177

## Test plan
- In the data browser, type filter text — clear button (×) appears; clicking it clears the field and triggers a reload
- While a filtered query is loading, the spinner replaces the clear button — they never overlap
- Open a table with foreign keys and switch to the Relations tab — related nodes show a pointer cursor on hover and open the correct table tab on click
- If that table tab is already open, clicking a node activates it rather than duplicating it
- For a table with cross-schema FK references, the correct schema's tab opens