### PR TITLE
feat: import connections from .pgpass file

### DIFF
--- a/Tusk.xcodeproj/project.pbxproj
+++ b/Tusk.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		9EF64556295E01772AA50486 /* FunctionDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F1FC4557C5B581972CE00D /* FunctionDetailView.swift */; };
 		A2845865FD833A6DE48D7963 /* SQLTextEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07B5D84046EF2C8F752BDD6C /* SQLTextEditor.swift */; };
 		B2123B053A58F7D78FEE550A /* SettingsPopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F1C8E9BF3BF31794B0FF27A /* SettingsPopover.swift */; };
+		B2A213CD67282059C4F6BF65 /* ImportPgpassSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F6038974D90CCB0515EE83 /* ImportPgpassSheet.swift */; };
 		B3A1EC28832572F3CC389E9B /* Connection.swift in Sources */ = {isa = PBXBuildFile; fileRef = B48A2CA1E506E6FDF0786437 /* Connection.swift */; };
 		B4EC8AF4B1FDCE660985FCA1 /* SQLHighlighter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CCC2BABC5778B46E7417764 /* SQLHighlighter.swift */; };
 		BDF57DF2459313BCFB4DDD3D /* AboutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1576217C7FBD3F87C830FD0 /* AboutView.swift */; };
@@ -43,6 +44,7 @@
 		DAECA2B92659612616C8E742 /* SidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09DE3A60259B635D1BA6AEE2 /* SidebarView.swift */; };
 		DE4F3724A5C82253871A3906 /* TuskApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAC42E3023CAE6227191B992 /* TuskApp.swift */; };
 		E089453CC03E346608C81935 /* AddConstraintSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF9AE44C9B548E1F4421ABD /* AddConstraintSheet.swift */; };
+		E261F6FFA021917237C6D8B4 /* PgpassImporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E076541405A093D0D492A269 /* PgpassImporter.swift */; };
 		EBAD0BABD60043A2CFC574C9 /* SSHTunnel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F7C45A0E07237D92F1C1FC4 /* SSHTunnel.swift */; };
 		ED65F385DAFD91259FA6AD73 /* FileExplorerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 009D995F865C1E2F42BA3F72 /* FileExplorerView.swift */; };
 		EF9609485D94E215A340F95B /* TableDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D84F6197423F6B815DCFF5EC /* TableDetailView.swift */; };
@@ -55,6 +57,7 @@
 		009D995F865C1E2F42BA3F72 /* FileExplorerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileExplorerView.swift; sourceTree = "<group>"; };
 		07B5D84046EF2C8F752BDD6C /* SQLTextEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLTextEditor.swift; sourceTree = "<group>"; };
 		09DE3A60259B635D1BA6AEE2 /* SidebarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarView.swift; sourceTree = "<group>"; };
+		14F6038974D90CCB0515EE83 /* ImportPgpassSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportPgpassSheet.swift; sourceTree = "<group>"; };
 		15B49B9D6360FE850DD93363 /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
 		193CE42C808DDA972A10DACE /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		1F1C8E9BF3BF31794B0FF27A /* SettingsPopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsPopover.swift; sourceTree = "<group>"; };
@@ -87,6 +90,7 @@
 		CD380525258BD900E61098D9 /* CreateRoleSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateRoleSheet.swift; sourceTree = "<group>"; };
 		D84F6197423F6B815DCFF5EC /* TableDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableDetailView.swift; sourceTree = "<group>"; };
 		DAC42E3023CAE6227191B992 /* TuskApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TuskApp.swift; sourceTree = "<group>"; };
+		E076541405A093D0D492A269 /* PgpassImporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PgpassImporter.swift; sourceTree = "<group>"; };
 		E1576217C7FBD3F87C830FD0 /* AboutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutView.swift; sourceTree = "<group>"; };
 		E1B1C7B5BED9E0D467D5CFED /* ConnectionStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionStore.swift; sourceTree = "<group>"; };
 		E2D7A2C8664E78D1A769D1C2 /* CreateTableSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateTableSheet.swift; sourceTree = "<group>"; };
@@ -138,6 +142,7 @@
 				E1B1C7B5BED9E0D467D5CFED /* ConnectionStore.swift */,
 				BA3E61CFF0505201909FC54F /* DatabaseClient.swift */,
 				0031996A15573BA8334CAB25 /* KeychainManager.swift */,
+				E076541405A093D0D492A269 /* PgpassImporter.swift */,
 				6F7C45A0E07237D92F1C1FC4 /* SSHTunnel.swift */,
 			);
 			path = Database;
@@ -256,6 +261,7 @@
 				37B4E572B48F16D9767046C1 /* AddConnectionSheet.swift */,
 				27CA54BB707DD57462515F8E /* CloudSQLInstancePickerSheet.swift */,
 				009D995F865C1E2F42BA3F72 /* FileExplorerView.swift */,
+				14F6038974D90CCB0515EE83 /* ImportPgpassSheet.swift */,
 				09DE3A60259B635D1BA6AEE2 /* SidebarView.swift */,
 			);
 			path = Sidebar;
@@ -354,7 +360,9 @@
 				ED65F385DAFD91259FA6AD73 /* FileExplorerView.swift in Sources */,
 				9EF64556295E01772AA50486 /* FunctionDetailView.swift in Sources */,
 				BEF51C28F2EF37A71F450340 /* HelpView.swift in Sources */,
+				B2A213CD67282059C4F6BF65 /* ImportPgpassSheet.swift in Sources */,
 				5EC184771B4FC8EB6B55DF1A /* KeychainManager.swift in Sources */,
+				E261F6FFA021917237C6D8B4 /* PgpassImporter.swift in Sources */,
 				16C056E3414DCF8938D6DFA4 /* QueryEditorView.swift in Sources */,
 				2E45EA7D8AE4CB19451C82E6 /* QueryResult.swift in Sources */,
 				2A084C868154BFE4D6EF03F6 /* RelationsView.swift in Sources */,

--- a/Tusk/AppState.swift
+++ b/Tusk/AppState.swift
@@ -49,6 +49,7 @@ final class AppState {
 
     // MARK: - UI state
     var isAddingConnection = false
+    var isImportingPgpass = false
     var isShowingSettings = false
     var editingConnection: Connection? = nil
     var connectingIDs: Set<UUID> = []

--- a/Tusk/Database/PgpassImporter.swift
+++ b/Tusk/Database/PgpassImporter.swift
@@ -20,10 +20,10 @@ struct PgpassEntry {
 
 enum PgpassImporter {
 
-    /// Reads the file at `url` and returns all valid, non-wildcard entries.
-    /// Lines that are comments (starting with `#`) or that have all five fields
-    /// as `*` are skipped. Lines with a wildcard in any single field are still
-    /// returned — the caller decides what to do with them.
+    /// Reads the file at `url` and returns all concrete, importable entries.
+    /// Lines that are comments (starting with `#`) or that have a wildcard in
+    /// any identifying field (host, database, username) are skipped, since they
+    /// cannot be turned into a concrete connection.
     static func parse(url: URL) throws -> [PgpassEntry] {
         let contents = try String(contentsOf: url, encoding: .utf8)
         return parse(string: contents)
@@ -47,19 +47,17 @@ enum PgpassImporter {
             let username = fields[3]
             let password = fields[4]
 
-            // Skip entries where every field is a wildcard — they can't be
-            // turned into a concrete connection.
-            if host == "*" && portStr == "*" && database == "*" && username == "*" {
-                continue
-            }
+            // Skip entries with wildcards in any identifying field — they can't
+            // be turned into a concrete connection.
+            guard host != "*", database != "*", username != "*" else { continue }
 
             let port = Int(portStr) ?? 5432
 
             entries.append(PgpassEntry(
-                host:     host == "*" ? "" : host,
+                host:     host,
                 port:     port,
-                database: database == "*" ? "" : database,
-                username: username == "*" ? "" : username,
+                database: database,
+                username: username,
                 password: password
             ))
         }

--- a/Tusk/Database/PgpassImporter.swift
+++ b/Tusk/Database/PgpassImporter.swift
@@ -1,0 +1,108 @@
+import Foundation
+
+// MARK: - PgpassEntry
+
+/// A single parsed entry from a .pgpass file.
+struct PgpassEntry {
+    let host: String
+    let port: Int
+    let database: String
+    let username: String
+    let password: String
+
+    /// A human-readable display name derived from the fields.
+    var suggestedName: String {
+        "\(username)@\(host):\(port)/\(database)"
+    }
+}
+
+// MARK: - PgpassImporter
+
+enum PgpassImporter {
+
+    /// Reads the file at `url` and returns all valid, non-wildcard entries.
+    /// Lines that are comments (starting with `#`) or that have all five fields
+    /// as `*` are skipped. Lines with a wildcard in any single field are still
+    /// returned — the caller decides what to do with them.
+    static func parse(url: URL) throws -> [PgpassEntry] {
+        let contents = try String(contentsOf: url, encoding: .utf8)
+        return parse(string: contents)
+    }
+
+    /// Parses the contents of a .pgpass file from a string.
+    static func parse(string: String) -> [PgpassEntry] {
+        var entries: [PgpassEntry] = []
+
+        for line in string.components(separatedBy: .newlines) {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            // Skip blank lines and comments
+            guard !trimmed.isEmpty, !trimmed.hasPrefix("#") else { continue }
+
+            let fields = splitPgpassLine(trimmed)
+            guard fields.count == 5 else { continue }
+
+            let host     = fields[0]
+            let portStr  = fields[1]
+            let database = fields[2]
+            let username = fields[3]
+            let password = fields[4]
+
+            // Skip entries where every field is a wildcard — they can't be
+            // turned into a concrete connection.
+            if host == "*" && portStr == "*" && database == "*" && username == "*" {
+                continue
+            }
+
+            let port = Int(portStr) ?? 5432
+
+            entries.append(PgpassEntry(
+                host:     host == "*" ? "" : host,
+                port:     port,
+                database: database == "*" ? "" : database,
+                username: username == "*" ? "" : username,
+                password: unescape(password)
+            ))
+        }
+
+        return entries
+    }
+
+    // MARK: - Private helpers
+
+    /// Splits a .pgpass line on unescaped `:` delimiters.
+    /// The spec allows `\:` and `\\` as escape sequences inside field values.
+    private static func splitPgpassLine(_ line: String) -> [String] {
+        var fields: [String] = []
+        var current = ""
+        var escaped = false
+
+        for ch in line {
+            if escaped {
+                current.append(ch)
+                escaped = false
+            } else if ch == "\\" {
+                escaped = true
+            } else if ch == ":" {
+                fields.append(current)
+                current = ""
+            } else {
+                current.append(ch)
+            }
+        }
+        fields.append(current)
+        return fields
+    }
+
+    /// Converts pgpass escape sequences in field values back to literal characters.
+    private static func unescape(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "\\:", with: ":")
+            .replacingOccurrences(of: "\\\\", with: "\\")
+    }
+
+    /// Returns the URL of the default ~/.pgpass file.
+    static var defaultURL: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".pgpass")
+    }
+}

--- a/Tusk/Database/PgpassImporter.swift
+++ b/Tusk/Database/PgpassImporter.swift
@@ -60,7 +60,7 @@ enum PgpassImporter {
                 port:     port,
                 database: database == "*" ? "" : database,
                 username: username == "*" ? "" : username,
-                password: unescape(password)
+                password: password
             ))
         }
 
@@ -91,13 +91,6 @@ enum PgpassImporter {
         }
         fields.append(current)
         return fields
-    }
-
-    /// Converts pgpass escape sequences in field values back to literal characters.
-    private static func unescape(_ value: String) -> String {
-        value
-            .replacingOccurrences(of: "\\:", with: ":")
-            .replacingOccurrences(of: "\\\\", with: "\\")
     }
 
     /// Returns the URL of the default ~/.pgpass file.

--- a/Tusk/Views/Sidebar/ImportPgpassSheet.swift
+++ b/Tusk/Views/Sidebar/ImportPgpassSheet.swift
@@ -10,6 +10,7 @@ struct ImportPgpassSheet: View {
     @State private var loadError: String? = nil
     @State private var isLoading = true
     @State private var fileURL: URL = PgpassImporter.defaultURL
+    @State private var loadGeneration = 0
 
     var body: some View {
         VStack(spacing: 0) {
@@ -114,6 +115,8 @@ struct ImportPgpassSheet: View {
     // MARK: - Load
 
     private func load(url: URL) async {
+        loadGeneration += 1
+        let generation = loadGeneration
         isLoading = true
         loadError = nil
         entries = []
@@ -124,6 +127,7 @@ struct ImportPgpassSheet: View {
             let parsed = try await Task.detached(priority: .userInitiated) {
                 try PgpassImporter.parse(url: url)
             }.value
+            guard generation == loadGeneration else { return }
             entries = parsed.map { entry in
                 let isDuplicate = connections.contains {
                     $0.host == entry.host &&
@@ -139,6 +143,7 @@ struct ImportPgpassSheet: View {
             }
             isLoading = false
         } catch {
+            guard generation == loadGeneration else { return }
             loadError = error.localizedDescription
             isLoading = false
         }

--- a/Tusk/Views/Sidebar/ImportPgpassSheet.swift
+++ b/Tusk/Views/Sidebar/ImportPgpassSheet.swift
@@ -55,7 +55,6 @@ struct ImportPgpassSheet: View {
                     TableColumn("") { entry in
                         Toggle("", isOn: bindingFor(entry))
                             .labelsHidden()
-                            .disabled(entry.status == .duplicate && !entry.selected)
                     }
                     .width(24)
                     TableColumn("Connection") { entry in
@@ -109,21 +108,24 @@ struct ImportPgpassSheet: View {
             .padding()
         }
         .frame(width: 720, height: 420)
-        .onAppear { load(url: fileURL) }
+        .onAppear { Task { await load(url: fileURL) } }
     }
 
     // MARK: - Load
 
-    private func load(url: URL) {
+    private func load(url: URL) async {
         isLoading = true
         loadError = nil
         entries = []
         fileURL = url
 
+        let connections = appState.connections
         do {
-            let parsed = try PgpassImporter.parse(url: url)
+            let parsed = try await Task.detached(priority: .userInitiated) {
+                try PgpassImporter.parse(url: url)
+            }.value
             entries = parsed.map { entry in
-                let isDuplicate = appState.connections.contains {
+                let isDuplicate = connections.contains {
                     $0.host == entry.host &&
                     $0.port == entry.port &&
                     $0.database == entry.database &&
@@ -180,7 +182,7 @@ struct ImportPgpassSheet: View {
         panel.allowsMultipleSelection = false
         panel.canChooseDirectories = false
         if panel.runModal() == .OK, let url = panel.url {
-            load(url: url)
+            Task { await load(url: url) }
         }
     }
 

--- a/Tusk/Views/Sidebar/ImportPgpassSheet.swift
+++ b/Tusk/Views/Sidebar/ImportPgpassSheet.swift
@@ -1,0 +1,210 @@
+import SwiftUI
+
+// MARK: - ImportPgpassSheet
+
+struct ImportPgpassSheet: View {
+    @Environment(AppState.self) private var appState
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var entries: [SelectableEntry] = []
+    @State private var loadError: String? = nil
+    @State private var isLoading = true
+    @State private var fileURL: URL = PgpassImporter.defaultURL
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Header
+            HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Import from .pgpass")
+                        .font(.headline)
+                    Text(fileURL.path)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+                Spacer()
+                Button("Choose File…") { pickFile() }
+                    .controlSize(.small)
+            }
+            .padding()
+
+            Divider()
+
+            // Content
+            if isLoading {
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if let error = loadError {
+                ContentUnavailableView(
+                    "Cannot Read File",
+                    systemImage: "exclamationmark.triangle",
+                    description: Text(error)
+                )
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if entries.isEmpty {
+                ContentUnavailableView(
+                    "No Importable Entries",
+                    systemImage: "doc.badge.ellipsis",
+                    description: Text("The file contains no concrete connection entries.")
+                )
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                Table(entries) {
+                    TableColumn("") { entry in
+                        Toggle("", isOn: bindingFor(entry))
+                            .labelsHidden()
+                            .disabled(entry.status == .duplicate && !entry.selected)
+                    }
+                    .width(24)
+                    TableColumn("Connection") { entry in
+                        VStack(alignment: .leading, spacing: 1) {
+                            Text(entry.pgpassEntry.suggestedName)
+                                .font(.system(.body, design: .monospaced))
+                            if entry.status == .duplicate {
+                                Text("Already exists")
+                                    .font(.caption)
+                                    .foregroundStyle(.orange)
+                            }
+                        }
+                    }
+                    TableColumn("Host") { entry in
+                        Text(entry.pgpassEntry.host.isEmpty ? "*" : entry.pgpassEntry.host)
+                            .foregroundStyle(entry.pgpassEntry.host.isEmpty ? .secondary : .primary)
+                    }
+                    TableColumn("Port") { entry in
+                        Text("\(entry.pgpassEntry.port)")
+                    }
+                    .width(48)
+                    TableColumn("Database") { entry in
+                        Text(entry.pgpassEntry.database.isEmpty ? "*" : entry.pgpassEntry.database)
+                            .foregroundStyle(entry.pgpassEntry.database.isEmpty ? .secondary : .primary)
+                    }
+                    TableColumn("User") { entry in
+                        Text(entry.pgpassEntry.username.isEmpty ? "*" : entry.pgpassEntry.username)
+                            .foregroundStyle(entry.pgpassEntry.username.isEmpty ? .secondary : .primary)
+                    }
+                }
+                .alternatingRowBackgrounds()
+            }
+
+            Divider()
+
+            // Footer
+            HStack {
+                if !entries.isEmpty {
+                    let selectedCount = entries.filter(\.selected).count
+                    Text("\(selectedCount) of \(entries.count) selected")
+                        .foregroundStyle(.secondary)
+                        .font(.caption)
+                }
+                Spacer()
+                Button("Cancel") { dismiss() }
+                    .keyboardShortcut(.cancelAction)
+                Button("Import") { performImport() }
+                    .keyboardShortcut(.defaultAction)
+                    .disabled(entries.filter(\.selected).isEmpty)
+            }
+            .padding()
+        }
+        .frame(width: 720, height: 420)
+        .onAppear { load(url: fileURL) }
+    }
+
+    // MARK: - Load
+
+    private func load(url: URL) {
+        isLoading = true
+        loadError = nil
+        entries = []
+        fileURL = url
+
+        do {
+            let parsed = try PgpassImporter.parse(url: url)
+            entries = parsed.map { entry in
+                let isDuplicate = appState.connections.contains {
+                    $0.host == entry.host &&
+                    $0.port == entry.port &&
+                    $0.database == entry.database &&
+                    $0.username == entry.username
+                }
+                return SelectableEntry(
+                    pgpassEntry: entry,
+                    selected: !isDuplicate,
+                    status: isDuplicate ? .duplicate : .new
+                )
+            }
+            isLoading = false
+        } catch {
+            loadError = error.localizedDescription
+            isLoading = false
+        }
+    }
+
+    // MARK: - Import
+
+    private func performImport() {
+        for entry in entries where entry.selected {
+            let conn = Connection(
+                name:     entry.pgpassEntry.suggestedName,
+                host:     entry.pgpassEntry.host,
+                port:     entry.pgpassEntry.port,
+                database: entry.pgpassEntry.database,
+                username: entry.pgpassEntry.username
+            )
+
+            if entry.status == .duplicate,
+               let existing = appState.connections.first(where: {
+                   $0.host == conn.host &&
+                   $0.port == conn.port &&
+                   $0.database == conn.database &&
+                   $0.username == conn.username
+               }) {
+                // Overwrite password only — keep existing connection metadata
+                KeychainManager.shared.setPassword(entry.pgpassEntry.password, for: existing.id)
+            } else {
+                appState.addConnection(conn)
+                KeychainManager.shared.setPassword(entry.pgpassEntry.password, for: conn.id)
+            }
+        }
+        dismiss()
+    }
+
+    // MARK: - File picker
+
+    private func pickFile() {
+        let panel = NSOpenPanel()
+        panel.title = "Select .pgpass file"
+        panel.allowedContentTypes = []   // any file
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+        if panel.runModal() == .OK, let url = panel.url {
+            load(url: url)
+        }
+    }
+
+    // MARK: - Binding helper
+
+    private func bindingFor(_ entry: SelectableEntry) -> Binding<Bool> {
+        Binding(
+            get: { entry.selected },
+            set: { newValue in
+                if let idx = entries.firstIndex(where: { $0.id == entry.id }) {
+                    entries[idx].selected = newValue
+                }
+            }
+        )
+    }
+}
+
+// MARK: - SelectableEntry
+
+private struct SelectableEntry: Identifiable {
+    let id = UUID()
+    let pgpassEntry: PgpassEntry
+    var selected: Bool
+    var status: Status
+
+    enum Status { case new, duplicate }
+}

--- a/Tusk/Views/Sidebar/ImportPgpassSheet.swift
+++ b/Tusk/Views/Sidebar/ImportPgpassSheet.swift
@@ -164,10 +164,14 @@ struct ImportPgpassSheet: View {
                    $0.username == conn.username
                }) {
                 // Overwrite password only — keep existing connection metadata
-                KeychainManager.shared.setPassword(entry.pgpassEntry.password, for: existing.id)
+                if !entry.pgpassEntry.password.isEmpty {
+                    KeychainManager.shared.setPassword(entry.pgpassEntry.password, for: existing.id)
+                }
             } else {
                 appState.addConnection(conn)
-                KeychainManager.shared.setPassword(entry.pgpassEntry.password, for: conn.id)
+                if !entry.pgpassEntry.password.isEmpty {
+                    KeychainManager.shared.setPassword(entry.pgpassEntry.password, for: conn.id)
+                }
             }
         }
         dismiss()

--- a/Tusk/Views/Sidebar/SidebarView.swift
+++ b/Tusk/Views/Sidebar/SidebarView.swift
@@ -102,13 +102,22 @@ struct SidebarView: View {
                 }
             }
             ToolbarItem(placement: .primaryAction) {
-                Button {
-                    appState.isAddingConnection = true
+                Menu {
+                    Button("New Connection…") {
+                        appState.isAddingConnection = true
+                    }
+                    Button("Import from .pgpass…") {
+                        appState.isImportingPgpass = true
+                    }
                 } label: {
                     Image(systemName: "plus")
                 }
+                .menuIndicator(.hidden)
                 .help("Add connection")
             }
+        }
+        .sheet(isPresented: $appState.isImportingPgpass) {
+            ImportPgpassSheet()
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add `PgpassImporter` — a spec-compliant parser for `~/.pgpass` files handling escape sequences (`\:`, `\\`), comments, and all-wildcard entries
- Add `ImportPgpassSheet` — a table view showing parsed entries with checkboxes, duplicate detection (matched by host+port+database+username), skip/overwrite choice per duplicate, and async file parsing with a loading spinner; passwords are stored in the macOS Keychain on confirm
- Replace the sidebar `+` toolbar button with a Menu offering "New Connection…" and "Import from .pgpass…"; users can also browse to an alternative file via a file picker

## Issues
Closes #132

## Test plan
- Long-press or click the `+` button in the sidebar — a menu appears with "New Connection…" and "Import from .pgpass…"
- With a valid `~/.pgpass`, open the import sheet — entries load with a spinner, then appear in the table
- New entries are selected by default; duplicate connections (same host/port/database/username) are flagged "Already exists" and deselected by default
- Check a duplicate and click Import — only its Keychain password is updated, existing connection metadata is unchanged
- Uncheck a duplicate then re-check it — toggle is not locked (was a bug, now fixed)
- Click "Choose File…" and select a different `.pgpass` file — table refreshes
- With a non-existent or unreadable file, an error state is shown instead of a table
- Click Import with nothing selected — Import button is disabled
- `.pgpass` entries with `\:` or `\\` in the password are parsed correctly