### PR TITLE
ux+perf: data browser polish, sidebar debounce, parallel loads, column cache

### DIFF
--- a/Tusk/AppState.swift
+++ b/Tusk/AppState.swift
@@ -46,6 +46,9 @@ final class AppState {
     var superuserConnections: Set<UUID>             = []
     /// keyed by connectionID → cached role list (users + roles)
     var connectionRoles:      [UUID: [RoleInfo]]    = [:]
+    /// Column info cache — keyed by connectionID → "schema.table" → [ColumnInfo] (#214)
+    /// Invalidated on schema refresh and disconnect.
+    var columnCache:          [UUID: [String: [ColumnInfo]]] = [:]
 
     // MARK: - UI state
     var isAddingConnection = false
@@ -206,10 +209,14 @@ final class AppState {
         if (try? await refreshSchema(for: connection)) == nil {
             await loadSuperuserStatus(for: connection)
         }
+        // Load table sizes and databases concurrently — they are independent (#213)
         if UserDefaults.standard.bool(forKey: "tusk.sidebar.showTableSizes") {
-            await loadTableSizes(for: connection)
+            async let sizes: Void = loadTableSizes(for: connection)
+            async let dbs:   Void = loadDatabases(for: connection)
+            _ = await (sizes, dbs)
+        } else {
+            await loadDatabases(for: connection)
         }
-        await loadDatabases(for: connection)
     }
 
     func disconnect(_ connection: Connection) {
@@ -233,6 +240,7 @@ final class AppState {
         activeDatabase.removeValue(forKey: connection.id)
         superuserConnections.remove(connection.id)
         connectionRoles.removeValue(forKey: connection.id)
+        columnCache.removeValue(forKey: connection.id)
         if createTableTarget?.connectionID == connection.id {
             createTableTarget = nil
         }
@@ -301,11 +309,26 @@ final class AppState {
             schemaFunctions[connection.id] = f
             schemaNamesCache[connection.id] = n
             schemaRefreshErrors.removeValue(forKey: connection.id)
+            // Column metadata may have changed — invalidate the cache (#214)
+            columnCache.removeValue(forKey: connection.id)
             await loadSuperuserStatus(for: connection)
         } catch {
             schemaRefreshErrors[connection.id] = error.localizedDescription
             throw error
         }
+    }
+
+    /// Returns cached column info for a table, or fetches and caches it if not yet available.
+    /// Cache is invalidated on schema refresh and disconnect (#214).
+    func cachedColumns(connectionID: UUID, schema: String, table: String, using client: DatabaseClient) async throws -> [ColumnInfo] {
+        let key = "\(schema).\(table)"
+        if let cached = columnCache[connectionID]?[key] {
+            return cached
+        }
+        let cols = try await client.columns(schema: schema, table: table)
+        if columnCache[connectionID] == nil { columnCache[connectionID] = [:] }
+        columnCache[connectionID]?[key] = cols
+        return cols
     }
 
     // MARK: - Query tabs
@@ -592,6 +615,7 @@ final class AppState {
         schemaNamesCache.removeValue(forKey: connectionID)
         schemaTableSizes.removeValue(forKey: connectionID)
         schemaRefreshErrors.removeValue(forKey: connectionID)
+        columnCache.removeValue(forKey: connectionID)
 
         if (try? await refreshSchema(for: connection)) == nil {
             await loadSuperuserStatus(for: connection)

--- a/Tusk/Database/DatabaseClient.swift
+++ b/Tusk/Database/DatabaseClient.swift
@@ -551,12 +551,24 @@ actor DatabaseClient {
     // MARK: - Raw query
 
     func query(_ sql: String, rowLimit: Int? = nil) async throws -> QueryResult {
+        try await executeQuery(PostgresQuery(unsafeSQL: sql), rowLimit: rowLimit)
+    }
+
+    /// Executes a query where a single string parameter is bound as `$1`.
+    /// The full query is formed by concatenating `prefix`, the bound `filterParam`, and `suffix`.
+    /// This allows PostgreSQL to cache the query plan across different filter values.
+    func queryParameterized(prefix: String, filterParam: String, suffix: String, rowLimit: Int? = nil) async throws -> QueryResult {
+        let pgQuery: PostgresQuery = "\(unescaped: prefix)\(filterParam)\(unescaped: suffix)"
+        return try await executeQuery(pgQuery, rowLimit: rowLimit)
+    }
+
+    private func executeQuery(_ pgQuery: PostgresQuery, rowLimit: Int? = nil) async throws -> QueryResult {
         guard let conn = box?.connection else { throw TuskError.notConnected }
 
         let start = Date()
         let pgRows: PostgresRowSequence
         do {
-            pgRows = try await conn.query(PostgresQuery(unsafeSQL: sql), logger: logger)
+            pgRows = try await conn.query(pgQuery, logger: logger)
         } catch let psql as PSQLError {
             let msg = psql.serverInfo?[.message]
                 ?? psql.serverInfo?[.detail]

--- a/Tusk/Views/Main/DataBrowserView.swift
+++ b/Tusk/Views/Main/DataBrowserView.swift
@@ -163,6 +163,7 @@ struct DataBrowserView: View {
                 guard !state.filterText.isEmpty else { return }
                 state.offset = 0
                 triggerLoad()
+                triggerFilteredCount()
             }
 
             ZStack(alignment: .trailing) {

--- a/Tusk/Views/Main/DataBrowserView.swift
+++ b/Tusk/Views/Main/DataBrowserView.swift
@@ -192,11 +192,10 @@ struct DataBrowserView: View {
             }
             .frame(width: 220)
             .onChange(of: state.filterText) { _, newValue in
-                if newValue.isEmpty {
-                    state.countTask?.cancel()
-                    state.filteredRowCount = nil
-                    state.isLoadingFilteredCount = false
-                }
+                // Cancel any in-flight count whenever filter changes — stale results must not overwrite the new filter's count
+                state.countTask?.cancel()
+                state.filteredRowCount = nil
+                state.isLoadingFilteredCount = false
                 state.filterDebounceTask?.cancel()
                 state.filterDebounceTask = Task {
                     try? await Task.sleep(for: .milliseconds(300))
@@ -380,7 +379,7 @@ struct DataBrowserView: View {
                 if let col = state.filterColumn {
                     whereClause = " WHERE \(quoteIdentifier(col))::text ILIKE "
                 } else {
-                    whereClause = " WHERE \"\(tableName)\"::text ILIKE "
+                    whereClause = " WHERE \(quoteIdentifier(tableName))::text ILIKE "
                 }
                 queryResult = try await client.queryParameterized(
                     prefix: baseSQL + whereClause,
@@ -435,7 +434,7 @@ struct DataBrowserView: View {
         if let col = state.filterColumn {
             wherePrefix = "SELECT COUNT(*) FROM \(qualifiedName) WHERE \(quoteIdentifier(col))::text ILIKE "
         } else {
-            wherePrefix = "SELECT COUNT(*) FROM \(qualifiedName) WHERE \"\(tableName)\"::text ILIKE "
+            wherePrefix = "SELECT COUNT(*) FROM \(qualifiedName) WHERE \(quoteIdentifier(tableName))::text ILIKE "
         }
         guard let result = try? await client.queryParameterized(prefix: wherePrefix, filterParam: filterValue, suffix: ""),
               let row = result.rows.first,

--- a/Tusk/Views/Main/DataBrowserView.swift
+++ b/Tusk/Views/Main/DataBrowserView.swift
@@ -13,6 +13,12 @@ final class DataBrowserState {
     var filterColumn: String? = nil
     var loadTask: Task<Void, Never>? = nil
     var filterDebounceTask: Task<Void, Never>? = nil
+
+    // Row count display (#200)
+    var estimatedRowCount: Int64? = nil
+    var filteredRowCount: Int64? = nil
+    var isLoadingFilteredCount = false
+    var countTask: Task<Void, Never>? = nil
 }
 
 // MARK: - Data browser view
@@ -56,8 +62,11 @@ struct DataBrowserView: View {
             } else if let result = state.result {
                 VStack(spacing: 0) {
                     if result.rows.isEmpty {
+                        let canInsert = !isView && !isReadOnly && columns.contains(where: { $0.isPrimaryKey })
                         ContentUnavailableView("Empty Table", systemImage: "tray",
-                            description: Text("This table has no data."))
+                            description: Text(canInsert
+                                ? "This table has no data. Use the + button in the toolbar to add the first row."
+                                : "This table has no data."))
                             .frame(maxWidth: .infinity, maxHeight: .infinity)
                     } else {
                         ResultsGrid(
@@ -97,13 +106,19 @@ struct DataBrowserView: View {
                 Color(nsColor: .textBackgroundColor)
             }
         }
-        .task { if state.result == nil { triggerLoad() } }
+        .task {
+            if state.result == nil { triggerLoad() }
+            if state.estimatedRowCount == nil { await loadEstimatedRowCount() }
+        }
         .onChange(of: schemaName + "." + tableName) { _, _ in
             state.offset = 0
             state.filterColumn = nil
+            state.estimatedRowCount = nil
+            state.filteredRowCount = nil
             sortColumn = nil
             sortAscending = true
             triggerLoad()
+            Task { await loadEstimatedRowCount() }
         }
     }
 
@@ -130,6 +145,8 @@ struct DataBrowserView: View {
                 }
             }
 
+            rowCountView
+
             Spacer()
 
             Picker("Column", selection: $state.filterColumn) {
@@ -149,10 +166,14 @@ struct DataBrowserView: View {
             }
 
             ZStack(alignment: .trailing) {
-                TextField(state.filterColumn == nil ? "Filter all columns…" : "Filter \(state.filterColumn!)…",
-                          text: $state.filterText)
+                TextField(
+                    state.filterColumn == nil
+                        ? "Filter rows (case-insensitive, all columns)…"
+                        : "Filter \(state.filterColumn!) (case-insensitive)…",
+                    text: $state.filterText)
                     .textFieldStyle(.roundedBorder)
-                    .frame(width: 180)
+                    .frame(width: 220)
+                    .help("Filters using PostgreSQL ILIKE. Use % as a wildcard (e.g. %smith%).")
                 if state.isLoading && !state.filterText.isEmpty {
                     ProgressView()
                         .controlSize(.mini)
@@ -168,16 +189,22 @@ struct DataBrowserView: View {
                     .padding(.trailing, 6)
                 }
             }
-            .frame(width: 180)
-            .onChange(of: state.filterText) { _, _ in
-                    state.filterDebounceTask?.cancel()
-                    state.filterDebounceTask = Task {
-                        try? await Task.sleep(for: .milliseconds(300))
-                        guard !Task.isCancelled else { return }
-                        state.offset = 0
-                        triggerLoad()
-                    }
+            .frame(width: 220)
+            .onChange(of: state.filterText) { _, newValue in
+                if newValue.isEmpty {
+                    state.countTask?.cancel()
+                    state.filteredRowCount = nil
+                    state.isLoadingFilteredCount = false
                 }
+                state.filterDebounceTask?.cancel()
+                state.filterDebounceTask = Task {
+                    try? await Task.sleep(for: .milliseconds(300))
+                    guard !Task.isCancelled else { return }
+                    state.offset = 0
+                    triggerLoad()
+                    if !state.filterText.isEmpty { triggerFilteredCount() }
+                }
+            }
 
             Picker("Rows", selection: $pageSize) {
                 Text("50").tag(50)
@@ -289,6 +316,38 @@ struct DataBrowserView: View {
         .background(.bar)
     }
 
+    // MARK: - Row count view (#200)
+
+    @ViewBuilder
+    private var rowCountView: some View {
+        if let total = state.estimatedRowCount {
+            Group {
+                if !state.filterText.isEmpty {
+                    if state.isLoadingFilteredCount {
+                        HStack(spacing: 4) {
+                            ProgressView().controlSize(.mini)
+                            Text("of ~\(abbreviatedCount(total)) rows")
+                        }
+                    } else if let filtered = state.filteredRowCount {
+                        Text("\(filtered.formatted()) of ~\(abbreviatedCount(total)) rows")
+                    }
+                } else {
+                    Text("~\(abbreviatedCount(total)) rows")
+                }
+            }
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
+    }
+
+    private func abbreviatedCount(_ n: Int64) -> String {
+        switch n {
+        case ..<1_000:       return n.formatted()
+        case ..<1_000_000:   return String(format: "%.1fK", Double(n) / 1_000)
+        default:             return String(format: "%.1fM", Double(n) / 1_000_000)
+        }
+    }
+
     // MARK: - Load
 
     /// Cancels any in-flight load and starts a fresh one.
@@ -304,24 +363,32 @@ struct DataBrowserView: View {
         // Only clear isLoading when this task was not superseded by a newer one.
         defer { if !Task.isCancelled { state.isLoading = false } }
 
-        var sql = "SELECT * FROM \(qualifiedName)"
-
-        if !state.filterText.isEmpty {
-            if let col = state.filterColumn {
-                sql += " WHERE \(quoteIdentifier(col))::text ILIKE '%\(state.filterText.replacingOccurrences(of: "'", with: "''"))%'"
-            } else {
-                sql += " WHERE \"\(tableName)\"::text ILIKE '%\(state.filterText.replacingOccurrences(of: "'", with: "''"))%'"
-            }
-        }
-
+        let baseSQL = "SELECT * FROM \(qualifiedName)"
+        var orderAndPage = ""
         if let col = sortColumn {
-            sql += " ORDER BY \(quoteIdentifier(col)) \(sortAscending ? "ASC" : "DESC")"
+            orderAndPage += " ORDER BY \(quoteIdentifier(col)) \(sortAscending ? "ASC" : "DESC")"
         }
-
-        sql += " LIMIT \(effectivePageSize) OFFSET \(state.offset)"
+        orderAndPage += " LIMIT \(effectivePageSize) OFFSET \(state.offset)"
 
         do {
-            let queryResult = try await client.query(sql)
+            let queryResult: QueryResult
+            if !state.filterText.isEmpty {
+                // Use a parameterized query so PostgreSQL can cache the plan (#216)
+                let filterValue = "%\(state.filterText)%"
+                let whereClause: String
+                if let col = state.filterColumn {
+                    whereClause = " WHERE \(quoteIdentifier(col))::text ILIKE "
+                } else {
+                    whereClause = " WHERE \"\(tableName)\"::text ILIKE "
+                }
+                queryResult = try await client.queryParameterized(
+                    prefix: baseSQL + whereClause,
+                    filterParam: filterValue,
+                    suffix: orderAndPage
+                )
+            } else {
+                queryResult = try await client.query(baseSQL + orderAndPage)
+            }
             guard !Task.isCancelled else { return }
             state.result = queryResult
         } catch is CancellationError {
@@ -331,6 +398,49 @@ struct DataBrowserView: View {
             guard !Task.isCancelled else { return }
             state.error = error.localizedDescription
         }
+    }
+
+    // MARK: - Estimated row count (#200)
+
+    private func loadEstimatedRowCount() async {
+        let escapedSchema = schemaName.replacingOccurrences(of: "'", with: "''")
+        let escapedTable  = tableName.replacingOccurrences(of: "'", with: "''")
+        let sql = """
+            SELECT reltuples::bigint
+            FROM pg_class c
+            JOIN pg_namespace n ON n.oid = c.relnamespace
+            WHERE n.nspname = '\(escapedSchema)' AND c.relname = '\(escapedTable)'
+            """
+        guard let result = try? await client.query(sql),
+              let row = result.rows.first,
+              case .integer(let count) = row.first else { return }
+        state.estimatedRowCount = count >= 0 ? count : nil
+    }
+
+    private func triggerFilteredCount() {
+        state.countTask?.cancel()
+        state.isLoadingFilteredCount = true
+        state.countTask = Task { await loadFilteredCount() }
+    }
+
+    private func loadFilteredCount() async {
+        guard !Task.isCancelled, !state.filterText.isEmpty else {
+            state.isLoadingFilteredCount = false
+            return
+        }
+        defer { if !Task.isCancelled { state.isLoadingFilteredCount = false } }
+        let filterValue = "%\(state.filterText)%"
+        let wherePrefix: String
+        if let col = state.filterColumn {
+            wherePrefix = "SELECT COUNT(*) FROM \(qualifiedName) WHERE \(quoteIdentifier(col))::text ILIKE "
+        } else {
+            wherePrefix = "SELECT COUNT(*) FROM \(qualifiedName) WHERE \"\(tableName)\"::text ILIKE "
+        }
+        guard let result = try? await client.queryParameterized(prefix: wherePrefix, filterParam: filterValue, suffix: ""),
+              let row = result.rows.first,
+              case .integer(let count) = row.first,
+              !Task.isCancelled else { return }
+        state.filteredRowCount = count
     }
 
     // MARK: - Mutating SQL

--- a/Tusk/Views/Main/TableDetailView.swift
+++ b/Tusk/Views/Main/TableDetailView.swift
@@ -8,6 +8,7 @@ struct TableDetailView: View {
     var isView: Bool = false
     var isReadOnly: Bool = false
 
+    @Environment(AppState.self) private var appState
     @AppStorage("tusk.content.fontSize")   private var contentFontSize   = 13.0
     @AppStorage("tusk.content.fontDesign") private var contentFontDesign: TuskFontDesign = .sansSerif
 
@@ -600,7 +601,8 @@ struct TableDetailView: View {
 
     private func loadMeta() async {
         isLoadingMeta = true
-        async let cols = try? await client.columns(schema: schemaName, table: tableName)
+        // Use the AppState column cache so repeat opens are instant (#214)
+        async let cols = try? await appState.cachedColumns(connectionID: connectionID, schema: schemaName, table: tableName, using: client)
         async let fks  = try? await client.foreignKeys(schema: schemaName, table: tableName)
         columns     = await cols ?? []
         foreignKeys = await fks  ?? []

--- a/Tusk/Views/Sidebar/SidebarView.swift
+++ b/Tusk/Views/Sidebar/SidebarView.swift
@@ -245,6 +245,7 @@ private struct ConnectionSection: View {
         .onChange(of: schemaStamp, initial: true) { _, _ in
             cachedGrouped = computeGrouped()
         }
+        .onAppear { debouncedFilter = filterText }
         .onChange(of: filterText) { _, newValue in
             // Debounce the filter to avoid re-filtering on every keystroke (#211)
             filterDebounceTask?.cancel()

--- a/Tusk/Views/Sidebar/SidebarView.swift
+++ b/Tusk/Views/Sidebar/SidebarView.swift
@@ -134,6 +134,9 @@ private struct ConnectionSection: View {
     /// Cached result of the expensive grouping+sorting step.
     /// Populated by .onChange(of: schemaStamp, initial: true) — empty until first appear.
     @State private var cachedGrouped: [SchemaGroupEntry] = []
+    /// Debounced copy of filterText — updated 250 ms after the last keystroke (#211)
+    @State private var debouncedFilter: String = ""
+    @State private var filterDebounceTask: Task<Void, Never>? = nil
 
     var isConnected: Bool { appState.isConnected(connection) }
 
@@ -189,12 +192,12 @@ private struct ConnectionSection: View {
         }
     }
 
-    /// All schemas, public first then alphabetical. When `filterText` is non-empty,
+    /// All schemas, public first then alphabetical. When `debouncedFilter` is non-empty,
     /// each schema's object arrays are narrowed and empty schemas are omitted.
     /// Uses cachedGrouped for the expensive grouping step; filtering is a cheap second pass.
     private var schemas: [SchemaGroupEntry] {
         let grouped = cachedGrouped
-        let filter  = filterText.lowercased()
+        let filter  = debouncedFilter.lowercased()
 
         func matches(_ name: String) -> Bool { filter.isEmpty || name.lowercased().contains(filter) }
 
@@ -241,6 +244,15 @@ private struct ConnectionSection: View {
         }
         .onChange(of: schemaStamp, initial: true) { _, _ in
             cachedGrouped = computeGrouped()
+        }
+        .onChange(of: filterText) { _, newValue in
+            // Debounce the filter to avoid re-filtering on every keystroke (#211)
+            filterDebounceTask?.cancel()
+            filterDebounceTask = Task {
+                try? await Task.sleep(for: .milliseconds(250))
+                guard !Task.isCancelled else { return }
+                debouncedFilter = newValue
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Row count display in data browser toolbar with live filtered count (#200)
- Empty table shows insert CTA when the table is writable (#202)
- Filter placeholder/tooltip clarify ILIKE wildcard syntax; queries use parameterized SQL for plan caching (#205, #216)
- Sidebar schema filter debounced to 250 ms to reduce re-renders (#211)
- Table sizes and databases loaded concurrently on connect (#213)
- Column metadata cached in AppState to make repeat table opens instant (#214)

## Issues
Closes #200
Closes #202
Closes #205
Closes #211
Closes #213
Closes #214
Closes #216

## Test plan
- [ ] Open a large table — toolbar shows `~N rows` estimated count
- [ ] Type in the filter box — spinner + `of ~N rows` appears, then resolves to `X of ~N rows`
- [ ] Clear the filter — count resets to `~N rows`
- [ ] Change the column picker while a filter is active — filtered count refreshes
- [ ] Navigate to an empty writable table — CTA mentions the + button
- [ ] Navigate to an empty view or read-only table — CTA shows plain "no data" text
- [ ] Hover the filter box — tooltip explains ILIKE / % wildcard
- [ ] Type quickly in the sidebar filter — schema list updates only after a short pause
- [ ] Connect with `showTableSizes` enabled — connection completes without sizes blocking the DB list
- [ ] Open a table detail view twice — second open is noticeably faster (column fetch skipped)