### PR TITLE
ux: toolbar verbs, copy fixes, hints, tooltips, and empty states

### DIFF
--- a/Tusk/Views/Main/ActivityMonitorView.swift
+++ b/Tusk/Views/Main/ActivityMonitorView.swift
@@ -149,7 +149,7 @@ struct ActivityMonitorView: View {
                 }
                 .width(80)
 
-                TableColumn("Query") { entry in
+                TableColumn("Current Query") { entry in
                     let display = entry.query.isEmpty ? "—" : redactSQL(entry.query)
                     Text(display)
                         .lineLimit(1)

--- a/Tusk/Views/Main/EnumDetailView.swift
+++ b/Tusk/Views/Main/EnumDetailView.swift
@@ -14,7 +14,7 @@ struct EnumDetailView: View {
 
     @State private var values: [String] = []
     @State private var isLoading = true
-    @State private var loadFailed = false
+    @State private var loadError: String? = nil
     @State private var actionError: String? = nil
     @State private var showAddValueSheet = false
 
@@ -27,11 +27,11 @@ struct EnumDetailView: View {
             if isLoading {
                 ProgressView()
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
-            } else if loadFailed {
+            } else if let loadError {
                 ContentUnavailableView {
                     Label("Failed to Load Enum", systemImage: "exclamationmark.triangle")
                 } description: {
-                    Text("Could not retrieve values for \(schema).\(enumName).")
+                    Text(loadError)
                 } actions: {
                     Button("Retry") { Task { await reload() } }
                         .buttonStyle(.bordered)
@@ -133,21 +133,22 @@ struct EnumDetailView: View {
 
     private func reload() async {
         isLoading = true
-        loadFailed = false
+        loadError = nil
         // Re-fetch from the live cache in AppState if available, else fall back to a direct query.
         if let cached = appState.schemaEnums[connection.id]?.first(where: { $0.schema == schema && $0.name == enumName }) {
             values = cached.values
         } else {
-            if let all = try? await client.enums() {
+            do {
+                let all = try await client.enums()
                 if let found = all.first(where: { $0.schema == schema && $0.name == enumName }) {
                     values = found.values
                 } else {
                     values = []
-                    loadFailed = true
+                    loadError = "No enum named \(schema).\(enumName) was found."
                 }
-            } else {
+            } catch {
                 values = []
-                loadFailed = true
+                loadError = error.localizedDescription
             }
         }
         isLoading = false

--- a/Tusk/Views/Main/FunctionDetailView.swift
+++ b/Tusk/Views/Main/FunctionDetailView.swift
@@ -13,6 +13,7 @@ struct FunctionDetailView: View {
 
     @State private var detail: FunctionDetail? = nil
     @State private var isLoading = true
+    @State private var loadError: String? = nil
     @State private var isExecutorVisible = false
 
     private var isReadOnly: Bool { connection.isReadOnly }
@@ -40,7 +41,7 @@ struct FunctionDetailView: View {
                 ContentUnavailableView {
                     Label("Failed to Load Function", systemImage: "exclamationmark.triangle")
                 } description: {
-                    Text("Could not retrieve details for this function.")
+                    Text(loadError ?? "Could not retrieve details for this function.")
                 } actions: {
                     Button("Retry") { Task { await reload() } }
                         .buttonStyle(.bordered)
@@ -136,7 +137,13 @@ struct FunctionDetailView: View {
 
     private func reload() async {
         isLoading = true
-        detail = try? await client.functionDetail(oid: oid)
+        loadError = nil
+        do {
+            detail = try await client.functionDetail(oid: oid)
+        } catch {
+            detail = nil
+            loadError = error.localizedDescription
+        }
         isLoading = false
     }
 

--- a/Tusk/Views/Main/QueryEditorView.swift
+++ b/Tusk/Views/Main/QueryEditorView.swift
@@ -242,7 +242,11 @@ struct QueryEditorView: View {
     @ViewBuilder
     private var resultContent: some View {
         if executions.isEmpty {
-            Color(nsColor: .textBackgroundColor)
+            Text("Results will appear here after you run a query (⌘↵).")
+                .font(.callout)
+                .foregroundStyle(.tertiary)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(Color(nsColor: .textBackgroundColor))
         } else if selectedResultTab == 0 {
             executionLog
         } else {

--- a/Tusk/Views/Main/RoleDetailView.swift
+++ b/Tusk/Views/Main/RoleDetailView.swift
@@ -210,6 +210,7 @@ struct RoleDetailView: View {
                 membershipColumn(
                     title: "Member of",
                     items: memberships,
+                    emptyMessage: "This role is not a member of any groups.",
                     addHelp: "Grant membership in a role",
                     onAdd: { grantMembership(type: .memberOf) },
                     onRemove: { revokeMembership(roleName: $0, type: .memberOf) }
@@ -218,6 +219,7 @@ struct RoleDetailView: View {
                 membershipColumn(
                     title: "Has members",
                     items: members,
+                    emptyMessage: "No roles are members of this role.",
                     addHelp: "Grant a role membership here",
                     onAdd: { grantMembership(type: .hasMember) },
                     onRemove: { revokeMembership(roleName: $0, type: .hasMember) }
@@ -234,7 +236,7 @@ struct RoleDetailView: View {
     private enum MembershipType { case memberOf, hasMember }
 
     @ViewBuilder
-    private func membershipColumn(title: String, items: [String], addHelp: String, onAdd: @escaping () -> Void, onRemove: @escaping (String) -> Void) -> some View {
+    private func membershipColumn(title: String, items: [String], emptyMessage: String, addHelp: String, onAdd: @escaping () -> Void, onRemove: @escaping (String) -> Void) -> some View {
         VStack(alignment: .leading, spacing: 6) {
             HStack {
                 Text(title)
@@ -262,7 +264,7 @@ struct RoleDetailView: View {
                 Label("No Memberships", systemImage: "person.2")
                     .font(.system(size: contentFontSize - 1, design: contentFontDesign.design))
                     .foregroundStyle(.tertiary)
-                Text("This role is not a member of any groups.")
+                Text(emptyMessage)
                     .font(.system(size: contentFontSize - 2, design: contentFontDesign.design))
                     .foregroundStyle(.tertiary)
             } else {

--- a/Tusk/Views/Main/RoleDetailView.swift
+++ b/Tusk/Views/Main/RoleDetailView.swift
@@ -259,8 +259,11 @@ struct RoleDetailView: View {
                     .foregroundStyle(.orange)
                     .fixedSize(horizontal: false, vertical: true)
             } else if items.isEmpty {
-                Text("None")
+                Label("No Memberships", systemImage: "person.2")
                     .font(.system(size: contentFontSize - 1, design: contentFontDesign.design))
+                    .foregroundStyle(.tertiary)
+                Text("This role is not a member of any groups.")
+                    .font(.system(size: contentFontSize - 2, design: contentFontDesign.design))
                     .foregroundStyle(.tertiary)
             } else {
                 ForEach(items, id: \.self) { name in

--- a/Tusk/Views/Main/SequenceDetailView.swift
+++ b/Tusk/Views/Main/SequenceDetailView.swift
@@ -14,6 +14,7 @@ struct SequenceDetailView: View {
 
     @State private var detail: SequenceDetail? = nil
     @State private var isLoading = true
+    @State private var loadError: String? = nil
     @State private var setValueText: String = ""
     @State private var actionError: String? = nil
 
@@ -41,7 +42,7 @@ struct SequenceDetailView: View {
                 ContentUnavailableView {
                     Label("Failed to Load Sequence", systemImage: "exclamationmark.triangle")
                 } description: {
-                    Text("Could not retrieve details for \(schema).\(sequenceName).")
+                    Text(loadError ?? "Could not retrieve details for \(schema).\(sequenceName).")
                 } actions: {
                     Button("Retry") { Task { await reload() } }
                         .buttonStyle(.bordered)
@@ -162,7 +163,13 @@ struct SequenceDetailView: View {
 
     private func reload() async {
         isLoading = true
-        detail = try? await client.sequenceDetail(schema: schema, name: sequenceName)
+        loadError = nil
+        do {
+            detail = try await client.sequenceDetail(schema: schema, name: sequenceName)
+        } catch {
+            detail = nil
+            loadError = error.localizedDescription
+        }
         isLoading = false
     }
 

--- a/Tusk/Views/Main/TableDetailView.swift
+++ b/Tusk/Views/Main/TableDetailView.swift
@@ -521,7 +521,7 @@ struct TableDetailView: View {
                     Button {
                         showingCreateIndex = true
                     } label: {
-                        Label("Create Index", systemImage: "plus")
+                        Label("Add Index", systemImage: "plus")
                             .font(.caption)
                     }
                     .buttonStyle(.borderless)

--- a/Tusk/Views/Main/WelcomeView.swift
+++ b/Tusk/Views/Main/WelcomeView.swift
@@ -39,6 +39,15 @@ struct WelcomeView: View {
                 Text("Click any table in the sidebar to browse its data and schema.")
                     .foregroundStyle(.tertiary)
                     .font(.callout)
+
+                VStack(spacing: 6) {
+                    shortcutRow("⌘T", "New query tab")
+                    shortcutRow("⌘↵", "Run query")
+                    shortcutRow("⇧⌘↵", "Run current query")
+                    shortcutRow("⌘W", "Close tab")
+                    shortcutRow("⌘[ / ⌘]", "Previous / next tab")
+                }
+                .padding(.top, 8)
             } else {
                 Text("Select a connection in the sidebar to get started.")
                     .foregroundStyle(.tertiary)

--- a/Tusk/Views/Main/WelcomeView.swift
+++ b/Tusk/Views/Main/WelcomeView.swift
@@ -35,6 +35,10 @@ struct WelcomeView: View {
                 }
                 .buttonStyle(.borderedProminent)
                 .controlSize(.large)
+            } else if !appState.clients.isEmpty {
+                Text("Click any table in the sidebar to browse its data and schema.")
+                    .foregroundStyle(.tertiary)
+                    .font(.callout)
             } else {
                 Text("Select a connection in the sidebar to get started.")
                     .foregroundStyle(.tertiary)

--- a/Tusk/Views/Sidebar/AddConnectionSheet.swift
+++ b/Tusk/Views/Sidebar/AddConnectionSheet.swift
@@ -200,6 +200,7 @@ struct AddConnectionSheet: View {
                                 .foregroundStyle(.secondary)
                         }
                         Toggle("Read-only", isOn: $isReadOnly)
+                            .help("Prevents any INSERT, UPDATE, DELETE, or DDL statements from executing on this connection.")
                     }
 
                     Section {

--- a/Tusk/Views/Sidebar/AddConnectionSheet.swift
+++ b/Tusk/Views/Sidebar/AddConnectionSheet.swift
@@ -219,8 +219,10 @@ struct AddConnectionSheet: View {
                             TextField("Host", text: $host)
                             TextField("Port", text: $port)
                                 .frame(width: 70)
+                                .help("The PostgreSQL server port. Default is 5432.")
                         }
                         TextField("Database", text: $database)
+                            .help("The specific database to connect to. Leave blank to connect to the default database (usually your username).")
                     }
 
                     Section("Authentication") {
@@ -232,10 +234,12 @@ struct AddConnectionSheet: View {
                                 .padding(.leading, 16)
                         }
                         Toggle("Read-only", isOn: $isReadOnly)
+                            .help("Prevents any INSERT, UPDATE, DELETE, or DDL statements from executing on this connection.")
                     }
 
                     Section("SSH Tunnel") {
                         Toggle("Use SSH Tunnel", isOn: $sshEnabled)
+                            .help("Route the connection through an SSH server. Useful for databases not exposed to the public internet.")
 
                         if sshEnabled {
                             HStack {


### PR DESCRIPTION
## Summary
- Consistent "Add" verb across table inspector toolbar; Activity Monitor column renamed to "Current Query" (#204, #209)
- First-connection hint and SQL editor empty-state hint guide new users (#207, #203)
- `.help()` tooltips on AddConnectionSheet fields (Port, Database, Read-only, SSH Tunnel) — both Direct TCP and Cloud SQL sections (#208)
- RoleDetailView membership empty state uses ContentUnavailableView with context-appropriate copy per column (#210)
- Enum/Sequence/Function detail views show the actual error message on load failure (#206)

## Issues
Closes #203
Closes #204
Closes #206
Closes #207
Closes #208
Closes #209
Closes #210

## Test plan
- [ ] Table inspector Indexes tab — button reads "Add Index" (not "Create Index")
- [ ] Activity Monitor — SQL column header reads "Current Query"
- [ ] Connect to a DB, close all tabs — WelcomeView shows "Click any table…" hint with shortcut cheat-sheet
- [ ] Disconnect — hint reverts to "Select a connection in the sidebar to get started."
- [ ] Open a new SQL editor tab — results pane shows tertiary hint; disappears after first query
- [ ] Add Connection sheet (Direct TCP) — hover Port, Database, Read-only, SSH Tunnel for tooltips
- [ ] Add Connection sheet (Cloud SQL) — hover Read-only toggle for tooltip
- [ ] Open a role with no memberships — both columns show "No Memberships" with correct description
- [ ] Simulate an enum/sequence/function load failure — actual error shown, not hardcoded string