### PR TITLE
perf+ux+feat: cache SQL redaction, cap executions, confirm delete, notifications

### DIFF
--- a/Tusk/Models/Connection.swift
+++ b/Tusk/Models/Connection.swift
@@ -171,11 +171,18 @@ struct TableSchema: Sendable {
 // MARK: - Activity monitor entry
 
 /// Masks plaintext passwords so they never appear in the UI.
-/// Covers: PASSWORD 'literal'
+/// Covers: PASSWORD 'literal'  PASSWORD $$secret$$  PASSWORD $tag$secret$tag$
 func redactSQLForDisplay(_ sql: String) -> String {
     guard sql.localizedCaseInsensitiveContains("password") else { return sql }
-    let pattern = #"(?i)\bPASSWORD\s+'[^']*'"#
-    return sql.replacingOccurrences(of: pattern, with: "PASSWORD '***'", options: .regularExpression)
+    let patterns = [
+        #"(?i)\bPASSWORD\s+'[^']*'"#,          // single-quoted:  PASSWORD 'secret'
+        #"(?i)\bPASSWORD\s+(\$[^$]*\$).*?\1"#, // dollar-quoted:  PASSWORD $$secret$$
+    ]
+    var result = sql
+    for pattern in patterns {
+        result = result.replacingOccurrences(of: pattern, with: "PASSWORD '***'", options: .regularExpression)
+    }
+    return result
 }
 
 struct ActivityEntry: Identifiable, Sendable {

--- a/Tusk/Models/Connection.swift
+++ b/Tusk/Models/Connection.swift
@@ -170,15 +170,37 @@ struct TableSchema: Sendable {
 
 // MARK: - Activity monitor entry
 
+/// Masks plaintext passwords so they never appear in the UI.
+/// Covers: PASSWORD 'literal'
+func redactSQLForDisplay(_ sql: String) -> String {
+    guard sql.localizedCaseInsensitiveContains("password") else { return sql }
+    let pattern = #"(?i)\bPASSWORD\s+'[^']*'"#
+    return sql.replacingOccurrences(of: pattern, with: "PASSWORD '***'", options: .regularExpression)
+}
+
 struct ActivityEntry: Identifiable, Sendable {
     let pid: Int
     var id: Int { pid }
     let applicationName: String
     let state: String           // active, idle, idle in transaction, …
     let query: String
+    /// SQL with passwords redacted — computed once at init, used by the UI.
+    let displayQuery: String
     let durationSeconds: Int?   // nil when query_start is NULL
     let waitEventType: String?
     let waitEvent: String?
+
+    init(pid: Int, applicationName: String, state: String, query: String,
+         durationSeconds: Int?, waitEventType: String?, waitEvent: String?) {
+        self.pid = pid
+        self.applicationName = applicationName
+        self.state = state
+        self.query = query
+        self.displayQuery = query.isEmpty ? "—" : redactSQLForDisplay(query)
+        self.durationSeconds = durationSeconds
+        self.waitEventType = waitEventType
+        self.waitEvent = waitEvent
+    }
 }
 
 // MARK: - Table size info

--- a/Tusk/Models/Constants.swift
+++ b/Tusk/Models/Constants.swift
@@ -1,2 +1,6 @@
 /// Shared page size used by the query editor row cap and the data browser.
 let tuskPageSize = 1_000
+
+/// Maximum number of execution entries retained per query tab.
+/// Older entries are dropped when this limit is exceeded within a single run.
+let executionHistoryCap = 50

--- a/Tusk/TuskApp.swift
+++ b/Tusk/TuskApp.swift
@@ -14,7 +14,7 @@ struct TuskApp: App {
                 .onAppear {
                     UNUserNotificationCenter.current().delegate = notificationDelegate
                 }
-                .onReceive(NotificationCenter.default.publisher(for: .tuskActivateQueryTab)) { note in
+                .onReceive(NotificationCenter.default.publisher(for: .tuskActivateQueryTab).receive(on: RunLoop.main)) { note in
                     guard let tabID = note.userInfo?["tabID"] as? UUID,
                           let detailTab = appState.openTabs.first(where: {
                               guard case .queryEditor(let qid) = $0.kind else { return false }

--- a/Tusk/TuskApp.swift
+++ b/Tusk/TuskApp.swift
@@ -1,14 +1,28 @@
 import SwiftUI
+import UserNotifications
 
 @main
 struct TuskApp: App {
     @State private var appState = AppState()
+    private let notificationDelegate = QueryNotificationDelegate()
 
     var body: some Scene {
         WindowGroup {
             ContentView()
                 .environment(appState)
                 .frame(minWidth: 900, minHeight: 600)
+                .onAppear {
+                    UNUserNotificationCenter.current().delegate = notificationDelegate
+                }
+                .onReceive(NotificationCenter.default.publisher(for: .tuskActivateQueryTab)) { note in
+                    guard let tabID = note.userInfo?["tabID"] as? UUID,
+                          let detailTab = appState.openTabs.first(where: {
+                              guard case .queryEditor(let qid) = $0.kind else { return false }
+                              return appState.queryTabs.first(where: { $0.id == qid })?.id == tabID
+                          }) else { return }
+                    NSApp.activate(ignoringOtherApps: true)
+                    appState.activeDetailTabID = detailTab.id
+                }
         }
         .windowStyle(.titleBar)
         .windowToolbarStyle(.unified)
@@ -30,5 +44,30 @@ struct TuskApp: App {
             HelpView()
         }
         .windowResizability(.contentSize)
+    }
+}
+
+// MARK: - Notification delegate
+
+extension Notification.Name {
+    static let tuskActivateQueryTab = Notification.Name("tusk.activateQueryTab")
+}
+
+/// Handles taps on query-completion notifications — posts a notification to activate the tab.
+final class QueryNotificationDelegate: NSObject, UNUserNotificationCenterDelegate, Sendable {
+    func userNotificationCenter(_ center: UNUserNotificationCenter,
+                                didReceive response: UNNotificationResponse,
+                                withCompletionHandler completionHandler: @escaping () -> Void) {
+        defer { completionHandler() }
+        guard let tabIDString = response.notification.request.content.userInfo["tabID"] as? String,
+              let tabID = UUID(uuidString: tabIDString) else { return }
+        NotificationCenter.default.post(name: .tuskActivateQueryTab, object: nil, userInfo: ["tabID": tabID])
+    }
+
+    func userNotificationCenter(_ center: UNUserNotificationCenter,
+                                willPresent notification: UNNotification,
+                                withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+        // Don't show banner when app is frontmost — the user can see the result directly
+        completionHandler([])
     }
 }

--- a/Tusk/Views/Components/SettingsPopover.swift
+++ b/Tusk/Views/Components/SettingsPopover.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import UserNotifications
 
 struct SettingsPopover: View {
     @Environment(\.openWindow) private var openWindow

--- a/Tusk/Views/Components/SettingsPopover.swift
+++ b/Tusk/Views/Components/SettingsPopover.swift
@@ -1,13 +1,15 @@
 import SwiftUI
+import UserNotifications
 
 struct SettingsPopover: View {
     @Environment(\.openWindow) private var openWindow
-    @AppStorage("tusk.sidebar.fontSize")       private var sidebarFontSize   = 13.0
-    @AppStorage("tusk.sidebar.fontDesign")     private var sidebarFontDesign: TuskFontDesign = .sansSerif
-    @AppStorage("tusk.content.fontSize")       private var contentFontSize   = 13.0
-    @AppStorage("tusk.content.fontDesign")     private var contentFontDesign: TuskFontDesign = .sansSerif
-    @AppStorage("tusk.sidebar.showTableSizes") private var showTableSizes    = false
-    @AppStorage("tusk.dataBrowser.pageSize")   private var dataBrowserPageSize = 1_000
+    @AppStorage("tusk.sidebar.fontSize")             private var sidebarFontSize        = 13.0
+    @AppStorage("tusk.sidebar.fontDesign")           private var sidebarFontDesign: TuskFontDesign = .sansSerif
+    @AppStorage("tusk.content.fontSize")             private var contentFontSize        = 13.0
+    @AppStorage("tusk.content.fontDesign")           private var contentFontDesign: TuskFontDesign = .sansSerif
+    @AppStorage("tusk.sidebar.showTableSizes")       private var showTableSizes         = false
+    @AppStorage("tusk.dataBrowser.pageSize")         private var dataBrowserPageSize    = 1_000
+    @AppStorage("tusk.notifications.queryThreshold") private var queryNotifyThreshold   = 5
 
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
@@ -38,6 +40,28 @@ struct SettingsPopover: View {
 
             Divider()
             settingsSection("Content", fontDesign: $contentFontDesign, fontSize: $contentFontSize)
+
+            Divider()
+
+            Text("Notifications")
+                .font(.headline)
+
+            HStack {
+                Text("Notify after query")
+                    .font(.callout)
+                Spacer()
+                Picker("Notify after query", selection: $queryNotifyThreshold) {
+                    Text("Never").tag(-1)
+                    Text("2 s").tag(2)
+                    Text("5 s").tag(5)
+                    Text("10 s").tag(10)
+                    Text("30 s").tag(30)
+                }
+                .pickerStyle(.menu)
+                .labelsHidden()
+                .frame(width: 80)
+            }
+            .font(.callout)
 
             Divider()
 

--- a/Tusk/Views/Main/ActivityMonitorView.swift
+++ b/Tusk/Views/Main/ActivityMonitorView.swift
@@ -150,8 +150,7 @@ struct ActivityMonitorView: View {
                 .width(80)
 
                 TableColumn("Current Query") { entry in
-                    let display = entry.query.isEmpty ? "—" : redactSQL(entry.query)
-                    Text(display)
+                    Text(entry.displayQuery)
                         .lineLimit(1)
                         .truncationMode(.tail)
                         .font(.system(size: contentFontSize - 1, design: .monospaced))
@@ -187,16 +186,6 @@ struct ActivityMonitorView: View {
         return Text(label)
             .font(.system(size: contentFontSize - 1, design: contentFontDesign.design))
             .foregroundStyle(color)
-    }
-
-    /// Replace plaintext passwords in SQL so they never appear in the UI.
-    /// Covers: PASSWORD 'literal'  PASSWORD NULL
-    private func redactSQL(_ sql: String) -> String {
-        guard sql.localizedCaseInsensitiveContains("password") else { return sql }
-        let pattern = #"(?i)\bPASSWORD\s+'[^']*'"#
-        let redacted = sql.replacingOccurrences(of: pattern, with: "PASSWORD '***'",
-                                                options: .regularExpression)
-        return redacted
     }
 
     private func formatDuration(_ seconds: Int) -> String {

--- a/Tusk/Views/Main/QueryEditorView.swift
+++ b/Tusk/Views/Main/QueryEditorView.swift
@@ -1,14 +1,17 @@
 import SwiftUI
+import UserNotifications
 
 struct QueryEditorView: View {
     @Environment(AppState.self) private var appState
-    @AppStorage("tusk.content.fontSize") private var contentFontSize = 13.0
+    @AppStorage("tusk.content.fontSize")             private var contentFontSize      = 13.0
+    @AppStorage("tusk.notifications.queryThreshold") private var queryNotifyThreshold = 5
     let tab: QueryTab
     let client: DatabaseClient?
 
     @State private var sql: String = ""
     @State private var selectedRange: NSRange = NSRange()
     @State private var executions: [ExecutionEntry] = []
+    @State private var executionsTruncated = false
     @State private var selectedResultTab: Int = 0   // 0 = Log, 1+ = Result N
     @State private var isRunning = false
     @State private var executeTask: Task<Void, Never>? = nil
@@ -290,6 +293,14 @@ struct QueryEditorView: View {
     private var executionLog: some View {
         ScrollView {
             LazyVStack(alignment: .leading, spacing: 0) {
+                if executionsTruncated {
+                    Text("Showing the \(executionHistoryCap) most recent results.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 6)
+                    Divider()
+                }
                 ForEach(executions) { entry in
                     executionLogRow(entry)
                     Divider()
@@ -469,6 +480,7 @@ struct QueryEditorView: View {
         guard !statements.isEmpty else { return }
 
         executions = []
+        executionsTruncated = false
         selectedResultTab = 0
         isRunning = true
         persistResultStateToTab()
@@ -481,6 +493,11 @@ struct QueryEditorView: View {
             }
             let idx = executions.count + 1
             executions.append(ExecutionEntry(index: idx, sql: stmt, outcome: .running))
+            // Cap history — drop the oldest entry when limit is exceeded
+            if executions.count > executionHistoryCap {
+                executions.removeFirst()
+                executionsTruncated = true
+            }
             let entryIndex = executions.count - 1
 
             let (finalSQL, capped) = cappedSQL(stmt)
@@ -538,6 +555,45 @@ struct QueryEditorView: View {
         if resultCount == 1 && !hasError { selectedResultTab = 1 }
 
         persistResultStateToTab()
+
+        // Fire a macOS notification if the query took long enough and the app is in the background
+        let totalDuration = executions.reduce(0.0) { sum, entry in
+            switch entry.outcome {
+            case .ok(let d):        return sum + d
+            case .rows(let r, _):   return sum + r.duration
+            default:                return sum
+            }
+        }
+        let threshold = queryNotifyThreshold
+        if threshold >= 0, totalDuration >= Double(threshold), !NSApp.isActive {
+            let connectionName = appState.connections.first(where: { $0.id == liveConnectionID })?.name ?? "Tusk"
+            sendQueryCompletionNotification(
+                connectionName: connectionName,
+                duration: totalDuration,
+                succeeded: !hasError,
+                tabID: tab.id
+            )
+        }
+    }
+
+    // MARK: - Notifications
+
+    private func sendQueryCompletionNotification(connectionName: String, duration: TimeInterval, succeeded: Bool, tabID: UUID) {
+        let center = UNUserNotificationCenter.current()
+        center.requestAuthorization(options: [.alert, .sound]) { granted, _ in
+            guard granted else { return }
+            let content = UNMutableNotificationContent()
+            content.title = succeeded ? "Query completed" : "Query failed"
+            let durationStr = duration < 60
+                ? String(format: "%.1f s", duration)
+                : String(format: "%.0f m %.0f s", floor(duration / 60), duration.truncatingRemainder(dividingBy: 60))
+            content.body = "\(connectionName) · \(durationStr)"
+            content.sound = .default
+            content.userInfo = ["tabID": tabID.uuidString]
+            let request = UNNotificationRequest(identifier: tabID.uuidString + "-\(Date().timeIntervalSince1970)",
+                                                content: content, trigger: nil)
+            center.add(request, withCompletionHandler: nil)
+        }
     }
 
     // MARK: - Explain

--- a/Tusk/Views/Sidebar/SidebarView.swift
+++ b/Tusk/Views/Sidebar/SidebarView.swift
@@ -1172,8 +1172,21 @@ private struct ConnectionHeader: View {
             Divider()
             Button("Duplicate") { appState.duplicateConnection(connection) }
             Button("Edit…") { appState.editingConnection = connection }
-            Button("Delete", role: .destructive) { appState.removeConnection(connection) }
+            Button("Delete", role: .destructive) { confirmDeleteConnection(connection) }
         }
+    }
+
+    // MARK: - Delete connection
+
+    private func confirmDeleteConnection(_ connection: Connection) {
+        let alert = NSAlert()
+        alert.messageText = "Delete \"\(connection.name)\"?"
+        alert.informativeText = "This will also remove its stored password from the Keychain."
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "Delete").hasDestructiveAction = true
+        alert.addButton(withTitle: "Cancel")
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+        appState.removeConnection(connection)
     }
 
     // MARK: - Create schema


### PR DESCRIPTION
## Summary
- Cache password redaction in `ActivityEntry.displayQuery` at init time so the regex never runs per-render; extend coverage to dollar-quoted passwords (`$$secret$$`)
- Cap execution history at 50 entries per run with a truncation banner to prevent unbounded memory growth
- Add NSAlert confirmation before deleting a connection (issue #201)
- Fire macOS background notifications when a slow query completes; user-configurable threshold in Settings (issue #198 / #212 / #215)

## Issues
Closes #198
Closes #201
Closes #212
Closes #215

## Test plan
- [ ] Activity monitor: run `ALTER ROLE u PASSWORD 'secret'` — verify query column shows `PASSWORD '***'`
- [ ] Activity monitor: run `ALTER ROLE u PASSWORD $$secret$$` — verify dollar-quoted password is also redacted
- [ ] Query editor: paste 55+ statements and run — verify oldest entries are dropped and the "Showing the 50 most recent results" banner appears
- [ ] Right-click a connection → Delete — verify an NSAlert confirmation appears before removal
- [ ] Settings popover: verify "Notifications" section appears with Never/2s/5s/10s/30s picker
- [ ] Set threshold to 2 s, hide Tusk, run a slow query — verify a macOS notification fires and tapping it brings the tab to front
- [ ] Set threshold to Never — verify no notification fires