### PR TITLE
feat: visual EXPLAIN plan viewer with node graph, pan/zoom, and cost colouring

### DIFF
--- a/Tusk.xcodeproj/project.pbxproj
+++ b/Tusk.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		EF9609485D94E215A340F95B /* TableDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D84F6197423F6B815DCFF5EC /* TableDetailView.swift */; };
 		FA1608BC33176CC583BE610B /* ExplainPlanView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F73CB2DC9ECA618E4D65A9DE /* ExplainPlanView.swift */; };
 		FB2DF2917401EB297E0173FA /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 193CE42C808DDA972A10DACE /* Constants.swift */; };
+		FCDDE405184AE961876101F8 /* ExplainGraphView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A21E2050EA43639A678CD93 /* ExplainGraphView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -64,6 +65,7 @@
 		1FF763FE618CB1AE4E595F53 /* Tusk.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Tusk.entitlements; sourceTree = "<group>"; };
 		27CA54BB707DD57462515F8E /* CloudSQLInstancePickerSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudSQLInstancePickerSheet.swift; sourceTree = "<group>"; };
 		37B4E572B48F16D9767046C1 /* AddConnectionSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddConnectionSheet.swift; sourceTree = "<group>"; };
+		3A21E2050EA43639A678CD93 /* ExplainGraphView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExplainGraphView.swift; sourceTree = "<group>"; };
 		54DB2C1EDCFE2EC1D9FC21ED /* QueryEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryEditorView.swift; sourceTree = "<group>"; };
 		615C3C512A905EBC9A2F5662 /* Tusk.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Tusk.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		61F1FC4557C5B581972CE00D /* FunctionDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FunctionDetailView.swift; sourceTree = "<group>"; };
@@ -195,6 +197,7 @@
 				75B070C67054E9379142805B /* ActivityMonitorView.swift */,
 				934FF1C0EBB58E15CCAFABEA /* DataBrowserView.swift */,
 				9D9E80D332E3F0E63E0DEBF9 /* EnumDetailView.swift */,
+				3A21E2050EA43639A678CD93 /* ExplainGraphView.swift */,
 				F73CB2DC9ECA618E4D65A9DE /* ExplainPlanView.swift */,
 				61F1FC4557C5B581972CE00D /* FunctionDetailView.swift */,
 				54DB2C1EDCFE2EC1D9FC21ED /* QueryEditorView.swift */,
@@ -356,6 +359,7 @@
 				D2C2E33CC9F0F6438C8814A7 /* DataBrowserView.swift in Sources */,
 				166F02A3D80B0F112F3C008C /* DatabaseClient.swift in Sources */,
 				4485D687490F834C172D3905 /* EnumDetailView.swift in Sources */,
+				FCDDE405184AE961876101F8 /* ExplainGraphView.swift in Sources */,
 				FA1608BC33176CC583BE610B /* ExplainPlanView.swift in Sources */,
 				ED65F385DAFD91259FA6AD73 /* FileExplorerView.swift in Sources */,
 				9EF64556295E01772AA50486 /* FunctionDetailView.swift in Sources */,

--- a/Tusk/Views/Main/ExplainGraphView.swift
+++ b/Tusk/Views/Main/ExplainGraphView.swift
@@ -1,0 +1,231 @@
+import SwiftUI
+
+// MARK: - Tree layout
+
+/// Computed layout for a single node in the graph canvas.
+struct PlanNodeLayout: Identifiable {
+    let id = UUID()
+    let node: ExplainNode
+    var centerX: CGFloat
+    var centerY: CGFloat
+    var children: [PlanNodeLayout]
+
+    // Card dimensions and spacing (base scale = 1.0)
+    static let cardW: CGFloat = 200
+    static let cardH: CGFloat = 76
+    static let hGap:  CGFloat = 18
+    static let vGap:  CGFloat = 52
+
+    // MARK: Layout
+
+    static func build(node: ExplainNode, topLeft: CGPoint) -> PlanNodeLayout {
+        let sw = subtreeWidth(node)
+        let cx = topLeft.x + sw / 2
+        let cy = topLeft.y + cardH / 2
+
+        guard !node.children.isEmpty else {
+            return PlanNodeLayout(node: node, centerX: cx, centerY: cy, children: [])
+        }
+
+        let childY = topLeft.y + cardH + vGap
+        var childX = topLeft.x
+        var childLayouts: [PlanNodeLayout] = []
+        for child in node.children {
+            let csw = subtreeWidth(child)
+            childLayouts.append(build(node: child, topLeft: CGPoint(x: childX, y: childY)))
+            childX += csw + hGap
+        }
+        let parentCX = (childLayouts.first!.centerX + childLayouts.last!.centerX) / 2
+        return PlanNodeLayout(node: node, centerX: parentCX, centerY: cy, children: childLayouts)
+    }
+
+    static func canvasSize(root: ExplainNode) -> CGSize {
+        let w = subtreeWidth(root)
+        let d = depth(root)
+        let h = CGFloat(d) * (cardH + vGap) - vGap + cardH
+        return CGSize(width: max(w, cardW), height: max(h, cardH))
+    }
+
+    /// Flattened list of all nodes in breadth-first order (for ForEach rendering).
+    func allLayouts() -> [PlanNodeLayout] {
+        var result: [PlanNodeLayout] = [self]
+        for child in children { result += child.allLayouts() }
+        return result
+    }
+
+    // MARK: Private helpers
+
+    private static func subtreeWidth(_ node: ExplainNode) -> CGFloat {
+        if node.children.isEmpty { return cardW }
+        let total = node.children.map { subtreeWidth($0) }.reduce(0, +)
+        let gaps  = CGFloat(node.children.count - 1) * hGap
+        return max(cardW, total + gaps)
+    }
+
+    private static func depth(_ node: ExplainNode) -> Int {
+        if node.children.isEmpty { return 1 }
+        return 1 + (node.children.map { depth($0) }.max() ?? 0)
+    }
+}
+
+// MARK: - Graph view
+
+struct ExplainGraphView: View {
+    let result: ExplainResult
+
+    @State private var scale: CGFloat = 1.0
+    @GestureState private var liveScale: CGFloat = 1.0
+
+    private var rootLayout: PlanNodeLayout {
+        PlanNodeLayout.build(node: result.plan, topLeft: .zero)
+    }
+
+    private var baseSize: CGSize {
+        PlanNodeLayout.canvasSize(root: result.plan)
+    }
+
+    private var maxNodeTime: Double {
+        func maxTime(_ node: ExplainNode) -> Double {
+            let t = node.actualTotalTime ?? 0
+            return ([t] + node.children.map { maxTime($0) }).max() ?? 0
+        }
+        return maxTime(result.plan)
+    }
+
+    var body: some View {
+        let effectiveScale = max(0.3, min(4.0, scale * liveScale))
+        let canvasW = baseSize.width  * effectiveScale
+        let canvasH = baseSize.height * effectiveScale
+        let layout  = rootLayout
+        let all     = layout.allLayouts()
+        let rootCost = result.plan.totalCost
+        let maxTime  = maxNodeTime
+
+        ScrollView([.horizontal, .vertical]) {
+            ZStack(alignment: .topLeading) {
+                // Edge layer
+                Canvas { ctx, _ in
+                    drawEdges(ctx: &ctx, layout: layout, scale: effectiveScale)
+                }
+                .frame(width: canvasW, height: canvasH)
+
+                // Node cards
+                ForEach(all) { nodeLayout in
+                    PlanNodeCard(
+                        layout:   nodeLayout,
+                        scale:    effectiveScale,
+                        rootCost: rootCost,
+                        maxTime:  maxTime
+                    )
+                }
+            }
+            .frame(width: canvasW, height: canvasH)
+        }
+        .background(Color(nsColor: .textBackgroundColor))
+        .gesture(
+            MagnificationGesture()
+                .updating($liveScale) { value, state, _ in state = value }
+                .onEnded { scale = max(0.3, min(4.0, scale * $0)) }
+        )
+    }
+
+    // MARK: - Edge drawing
+
+    private func drawEdges(ctx: inout GraphicsContext, layout: PlanNodeLayout, scale: CGFloat) {
+        for child in layout.children {
+            let from = CGPoint(x: layout.centerX * scale,
+                               y: (layout.centerY + PlanNodeLayout.cardH / 2) * scale)
+            let to   = CGPoint(x: child.centerX  * scale,
+                               y: (child.centerY  - PlanNodeLayout.cardH / 2) * scale)
+            var path = Path()
+            path.move(to: from)
+            path.addCurve(
+                to:       to,
+                control1: CGPoint(x: from.x, y: from.y + (to.y - from.y) * 0.5),
+                control2: CGPoint(x: to.x,   y: to.y   - (to.y - from.y) * 0.5)
+            )
+            ctx.stroke(path, with: .color(Color(nsColor: .separatorColor)), lineWidth: 1.5)
+            drawEdges(ctx: &ctx, layout: child, scale: scale)
+        }
+    }
+}
+
+// MARK: - Node card
+
+private struct PlanNodeCard: View {
+    let layout:   PlanNodeLayout
+    let scale:    CGFloat
+    let rootCost: Double
+    let maxTime:  Double
+
+    var body: some View {
+        let w = PlanNodeLayout.cardW * scale
+        let h = PlanNodeLayout.cardH * scale
+
+        VStack(alignment: .leading, spacing: 2 * scale) {
+            Text(nodeLabel)
+                .font(.system(size: 11 * scale, weight: .semibold))
+                .lineLimit(1)
+                .foregroundStyle(nodeColor)
+
+            Text(costLine)
+                .font(.system(size: 9.5 * scale, design: .monospaced))
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+
+            if let tl = timeLine {
+                Text(tl)
+                    .font(.system(size: 9.5 * scale, design: .monospaced))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+        }
+        .padding(.horizontal, 8 * scale)
+        .padding(.vertical, 6 * scale)
+        .frame(width: w, height: h, alignment: .topLeading)
+        .background(RoundedRectangle(cornerRadius: 8 * scale).fill(nodeColor.opacity(0.12)))
+        .overlay(RoundedRectangle(cornerRadius: 8 * scale)
+            .strokeBorder(nodeColor.opacity(0.5), lineWidth: 1.5 * scale))
+        .position(x: layout.centerX * scale, y: layout.centerY * scale)
+    }
+
+    private var nodeLabel: String {
+        var parts = [layout.node.nodeType]
+        if let rel = layout.node.relationName {
+            parts.append("on \(rel)")
+            if let alias = layout.node.alias, alias != rel { parts.append("(\(alias))") }
+        }
+        if let idx = layout.node.indexName { parts.append("using \(idx)") }
+        return parts.joined(separator: " ")
+    }
+
+    private var costLine: String {
+        String(format: "cost=%.2f..%.2f  rows=%d  width=%d",
+               layout.node.startupCost, layout.node.totalCost,
+               layout.node.planRows, layout.node.planWidth)
+    }
+
+    private var timeLine: String? {
+        guard let at = layout.node.actualTotalTime,
+              let ar = layout.node.actualRows,
+              let al = layout.node.actualLoops else { return nil }
+        return String(format: "actual=%.3f ms  rows=%d  loops=%d", at, ar, al)
+    }
+
+    private var nodeColor: Color {
+        let fraction: Double
+        if maxTime > 0, let t = layout.node.actualTotalTime {
+            fraction = t / maxTime
+        } else if rootCost > 0 {
+            fraction = layout.node.totalCost / rootCost
+        } else {
+            fraction = 0
+        }
+        switch fraction {
+        case ..<0.25: return .green
+        case ..<0.50: return Color(red: 0.65, green: 0.65, blue: 0.0)
+        case ..<0.75: return .orange
+        default:      return .red
+        }
+    }
+}

--- a/Tusk/Views/Main/ExplainGraphView.swift
+++ b/Tusk/Views/Main/ExplainGraphView.swift
@@ -16,37 +16,18 @@ struct PlanNodeLayout: Identifiable {
     static let hGap:  CGFloat = 18
     static let vGap:  CGFloat = 52
 
-    // MARK: Layout
+    // MARK: Layout entry point
 
-    static func build(node: ExplainNode, topLeft: CGPoint) -> PlanNodeLayout {
-        let sw = subtreeWidth(node)
-        let cx = topLeft.x + sw / 2
-        let cy = topLeft.y + cardH / 2
-
-        guard !node.children.isEmpty else {
-            return PlanNodeLayout(node: node, centerX: cx, centerY: cy, children: [])
-        }
-
-        let childY = topLeft.y + cardH + vGap
-        var childX = topLeft.x
-        var childLayouts: [PlanNodeLayout] = []
-        for child in node.children {
-            let csw = subtreeWidth(child)
-            childLayouts.append(build(node: child, topLeft: CGPoint(x: childX, y: childY)))
-            childX += csw + hGap
-        }
-        let parentCX = (childLayouts.first!.centerX + childLayouts.last!.centerX) / 2
-        return PlanNodeLayout(node: node, centerX: parentCX, centerY: cy, children: childLayouts)
-    }
-
-    static func canvasSize(root: ExplainNode) -> CGSize {
-        let w = subtreeWidth(root)
-        let d = depth(root)
+    /// Builds the layout tree and canvas size in a single traversal — no redundant subtree walks.
+    static func buildAll(node: ExplainNode) -> (layout: PlanNodeLayout, size: CGSize) {
+        let (layout, w) = build(node: node, topLeft: .zero)
+        let d = treeDepth(node)
         let h = CGFloat(d) * (cardH + vGap) - vGap
-        return CGSize(width: max(w, cardW), height: max(h, cardH))
+        let size = CGSize(width: max(w, cardW), height: max(h, cardH))
+        return (layout, size)
     }
 
-    /// Flattened list of all nodes in breadth-first order (for ForEach rendering).
+    /// Flattened list of all nodes depth-first (for ForEach rendering).
     func allLayouts() -> [PlanNodeLayout] {
         var result: [PlanNodeLayout] = [self]
         for child in children { result += child.allLayouts() }
@@ -55,16 +36,34 @@ struct PlanNodeLayout: Identifiable {
 
     // MARK: Private helpers
 
-    private static func subtreeWidth(_ node: ExplainNode) -> CGFloat {
-        if node.children.isEmpty { return cardW }
-        let total = node.children.map { subtreeWidth($0) }.reduce(0, +)
-        let gaps  = CGFloat(node.children.count - 1) * hGap
-        return max(cardW, total + gaps)
+    /// Returns (layout, subtreeWidth). Each subtree is traversed exactly once:
+    /// the child's width comes from the recursive return value, not a second subtreeWidth() call.
+    private static func build(node: ExplainNode, topLeft: CGPoint) -> (PlanNodeLayout, CGFloat) {
+        guard !node.children.isEmpty else {
+            let cx = topLeft.x + cardW / 2
+            let cy = topLeft.y + cardH / 2
+            return (PlanNodeLayout(node: node, centerX: cx, centerY: cy, children: []), cardW)
+        }
+
+        let childY = topLeft.y + cardH + vGap
+        var childX = topLeft.x
+        var childLayouts: [PlanNodeLayout] = []
+
+        for (i, child) in node.children.enumerated() {
+            let (childLayout, childW) = build(node: child, topLeft: CGPoint(x: childX, y: childY))
+            childLayouts.append(childLayout)
+            childX += childW + (i < node.children.count - 1 ? hGap : 0)
+        }
+
+        let sw = max(cardW, childX - topLeft.x)
+        let parentCX = (childLayouts.first!.centerX + childLayouts.last!.centerX) / 2
+        let cy = topLeft.y + cardH / 2
+        return (PlanNodeLayout(node: node, centerX: parentCX, centerY: cy, children: childLayouts), sw)
     }
 
-    private static func depth(_ node: ExplainNode) -> Int {
+    private static func treeDepth(_ node: ExplainNode) -> Int {
         if node.children.isEmpty { return 1 }
-        return 1 + (node.children.map { depth($0) }.max() ?? 0)
+        return 1 + (node.children.map { treeDepth($0) }.max() ?? 0)
     }
 }
 
@@ -74,48 +73,48 @@ struct ExplainGraphView: View {
     let result: ExplainResult
     private let rootLayout: PlanNodeLayout
     private let baseSize: CGSize
+    private let allNodeLayouts: [PlanNodeLayout]
+    private let maxNodeTime: Double
 
     @State private var scale: CGFloat = 1.0
     @GestureState private var liveScale: CGFloat = 1.0
 
     init(result: ExplainResult) {
-        self.result     = result
-        self.rootLayout = PlanNodeLayout.build(node: result.plan, topLeft: .zero)
-        self.baseSize   = PlanNodeLayout.canvasSize(root: result.plan)
-    }
-
-    private var maxNodeTime: Double {
-        func maxTime(_ node: ExplainNode) -> Double {
-            let t = node.actualTotalTime ?? 0
-            return ([t] + node.children.map { maxTime($0) }).max() ?? 0
-        }
-        return maxTime(result.plan)
+        self.result = result
+        let (layout, size) = PlanNodeLayout.buildAll(node: result.plan)
+        self.rootLayout     = layout
+        self.baseSize       = size
+        self.allNodeLayouts = layout.allLayouts()
+        // Compute max actual time once; used by PlanNodeCard for relative colour-coding
+        self.maxNodeTime = {
+            func maxT(_ node: ExplainNode) -> Double {
+                let t = node.actualTotalTime ?? 0
+                return ([t] + node.children.map { maxT($0) }).max() ?? 0
+            }
+            return maxT(result.plan)
+        }()
     }
 
     var body: some View {
         let effectiveScale = max(0.3, min(4.0, scale * liveScale))
         let canvasW = baseSize.width  * effectiveScale
         let canvasH = baseSize.height * effectiveScale
-        let layout  = rootLayout
-        let all     = layout.allLayouts()
-        let rootCost = result.plan.totalCost
-        let maxTime  = maxNodeTime
 
         ScrollView([.horizontal, .vertical]) {
             ZStack(alignment: .topLeading) {
                 // Edge layer
                 Canvas { ctx, _ in
-                    drawEdges(ctx: &ctx, layout: layout, scale: effectiveScale)
+                    drawEdges(ctx: &ctx, layout: rootLayout, scale: effectiveScale)
                 }
                 .frame(width: canvasW, height: canvasH)
 
-                // Node cards
-                ForEach(all) { nodeLayout in
+                // Node cards — pre-flattened list avoids tree traversal in body
+                ForEach(allNodeLayouts) { nodeLayout in
                     PlanNodeCard(
                         layout:   nodeLayout,
                         scale:    effectiveScale,
-                        rootCost: rootCost,
-                        maxTime:  maxTime
+                        rootCost: result.plan.totalCost,
+                        maxTime:  maxNodeTime
                     )
                 }
             }

--- a/Tusk/Views/Main/ExplainGraphView.swift
+++ b/Tusk/Views/Main/ExplainGraphView.swift
@@ -42,7 +42,7 @@ struct PlanNodeLayout: Identifiable {
     static func canvasSize(root: ExplainNode) -> CGSize {
         let w = subtreeWidth(root)
         let d = depth(root)
-        let h = CGFloat(d) * (cardH + vGap) - vGap + cardH
+        let h = CGFloat(d) * (cardH + vGap) - vGap
         return CGSize(width: max(w, cardW), height: max(h, cardH))
     }
 
@@ -72,16 +72,16 @@ struct PlanNodeLayout: Identifiable {
 
 struct ExplainGraphView: View {
     let result: ExplainResult
+    private let rootLayout: PlanNodeLayout
+    private let baseSize: CGSize
 
     @State private var scale: CGFloat = 1.0
     @GestureState private var liveScale: CGFloat = 1.0
 
-    private var rootLayout: PlanNodeLayout {
-        PlanNodeLayout.build(node: result.plan, topLeft: .zero)
-    }
-
-    private var baseSize: CGSize {
-        PlanNodeLayout.canvasSize(root: result.plan)
+    init(result: ExplainResult) {
+        self.result     = result
+        self.rootLayout = PlanNodeLayout.build(node: result.plan, topLeft: .zero)
+        self.baseSize   = PlanNodeLayout.canvasSize(root: result.plan)
     }
 
     private var maxNodeTime: Double {

--- a/Tusk/Views/Main/ExplainPlanView.swift
+++ b/Tusk/Views/Main/ExplainPlanView.swift
@@ -1,14 +1,20 @@
 import SwiftUI
 
+private enum ExplainViewMode: String, CaseIterable {
+    case tree  = "Tree"
+    case graph = "Graph"
+}
+
 struct ExplainPlanView: View {
     let result: ExplainResult
 
     @AppStorage("tusk.content.fontSize")   private var fontSize   = 13.0
     @AppStorage("tusk.content.fontDesign") private var fontDesign: TuskFontDesign = .sansSerif
+    @State private var viewMode: ExplainViewMode = .tree
 
     var body: some View {
         VStack(spacing: 0) {
-            // Footer bar: planning + execution time
+            // Header bar: timing stats + view toggle
             HStack(spacing: 6) {
                 if let exec = result.executionMs {
                     Text(String(format: "Execution: %.3f ms", exec))
@@ -26,6 +32,14 @@ struct ExplainPlanView: View {
                     .font(.system(size: fontSize - 1, design: fontDesign.design))
                     .foregroundStyle(.secondary)
                 Spacer()
+                Picker("View", selection: $viewMode) {
+                    ForEach(ExplainViewMode.allCases, id: \.self) { mode in
+                        Text(mode.rawValue).tag(mode)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .fixedSize()
+                .controlSize(.small)
             }
             .padding(.horizontal, 12)
             .padding(.vertical, 6)
@@ -33,15 +47,20 @@ struct ExplainPlanView: View {
 
             Divider()
 
-            ScrollView([.vertical, .horizontal]) {
-                LazyVStack(alignment: .leading, spacing: 0) {
-                    ExplainNodeRow(node: result.plan, depth: 0,
-                                  totalCost: result.plan.totalCost,
-                                  fontSize: fontSize, fontDesign: fontDesign.design)
+            switch viewMode {
+            case .tree:
+                ScrollView([.vertical, .horizontal]) {
+                    LazyVStack(alignment: .leading, spacing: 0) {
+                        ExplainNodeRow(node: result.plan, depth: 0,
+                                      totalCost: result.plan.totalCost,
+                                      fontSize: fontSize, fontDesign: fontDesign.design)
+                    }
+                    .padding(12)
                 }
-                .padding(12)
+                .background(Color(nsColor: .textBackgroundColor))
+            case .graph:
+                ExplainGraphView(result: result)
             }
-            .background(Color(nsColor: .textBackgroundColor))
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add a Tree / Graph toggle to the EXPLAIN plan result tab
- New graph view renders a node-graph using SwiftUI Canvas for Bézier edges and positioned node cards; each card shows node type, estimated cost, and actual time/rows/loops (when ANALYZE data is present)
- Nodes are colour-coded by relative cost (green → yellow → orange → red); layout and canvas size are computed once at init for efficient zoom re-renders

## Issues
Closes #197

## Test plan
- [ ] Run `EXPLAIN (ANALYZE, FORMAT JSON) SELECT ...` — verify the Plan tab shows the Tree view by default (existing behaviour unchanged)
- [ ] Click "Graph" in the segmented toggle — verify a node-graph renders with node cards connected by Bézier curves
- [ ] Each node card shows node type, cost line, and actual time/rows/loops when ANALYZE data is present
- [ ] Expensive nodes (>75% of max time) are red; cheap nodes (<25%) are green
- [ ] Multi-join query (Hash Join, Nested Loop, Index Scan) — all node types render with correct parent→child edges
- [ ] Scroll horizontally/vertically on a wide plan — trackpad panning works
- [ ] Pinch-to-zoom — scale applies smoothly; scroll area updates to fit zoomed content
- [ ] Plain `EXPLAIN` (no ANALYZE) — Graph renders using estimated cost fractions; no actual-time line in cards
- [ ] Switch back to Tree — text tree is restored