### PR TITLE
feat: SSH agent support for SSH tunnel authentication (#199)

### DIFF
--- a/Tusk/AppState.swift
+++ b/Tusk/AppState.swift
@@ -153,7 +153,7 @@ final class AppState {
         } else if connection.sshEnabled {
             // Start SSH tunnel if enabled; the tunnel exposes a local port that
             // PostgresNIO will connect to instead of the real host/port.
-            let passphrase = KeychainManager.shared.sshPassphrase(for: connection.id)
+            let passphrase = connection.sshUseAgent ? nil : KeychainManager.shared.sshPassphrase(for: connection.id)
             let tunnel = SSHTunnel()
             try await tunnel.start(connection: connection, passphrase: passphrase)
             newTunnel = tunnel

--- a/Tusk/Database/SSHTunnel.swift
+++ b/Tusk/Database/SSHTunnel.swift
@@ -13,32 +13,51 @@ actor SSHTunnel {
     func start(connection: Connection, passphrase: String?) async throws {
         localPort = try Self.findFreePort()
 
-        // Write a temp askpass script if a passphrase is needed.
-        // SSH calls it when prompted for the key passphrase.
+        var env = ProcessInfo.processInfo.environment
         var askpassURL: URL? = nil
-        if let passphrase, !passphrase.isEmpty {
-            askpassURL = try Self.writeAskpassScript(passphrase: passphrase)
-        }
 
         let p = Process()
         p.executableURL = URL(fileURLWithPath: "/usr/bin/ssh")
-        p.arguments = [
-            "-N",
-            "-L", "\(localPort):\(connection.host):\(connection.port)",
-            "-p", "\(connection.sshPort)",
-            "-i", connection.sshKeyPath,
-            "-o", "StrictHostKeyChecking=accept-new",
-            "-o", "ExitOnForwardFailure=yes",
-            "-o", "BatchMode=\(passphrase == nil || passphrase!.isEmpty ? "yes" : "no")",
-            "-o", "ServerAliveInterval=30",
-            "\(connection.sshUser)@\(connection.sshHost)"
-        ]
 
-        var env = ProcessInfo.processInfo.environment
-        if let url = askpassURL {
-            env["SSH_ASKPASS"]         = url.path
-            env["SSH_ASKPASS_REQUIRE"] = "force"
-            env["DISPLAY"]             = ":0"
+        if connection.sshUseAgent {
+            // Agent mode: ssh picks up identities from SSH_AUTH_SOCK automatically.
+            // No -i flag, no BatchMode override (agent handles auth interactively if needed).
+            guard let sock = env["SSH_AUTH_SOCK"], !sock.isEmpty else {
+                throw TuskError.sshTunnelFailed(
+                    "SSH_AUTH_SOCK is not set. Start your SSH agent (or launch Tusk from a " +
+                    "terminal where the agent is running) and try again."
+                )
+            }
+            p.arguments = [
+                "-N",
+                "-L", "\(localPort):\(connection.host):\(connection.port)",
+                "-p", "\(connection.sshPort)",
+                "-o", "StrictHostKeyChecking=accept-new",
+                "-o", "ExitOnForwardFailure=yes",
+                "-o", "ServerAliveInterval=30",
+                "\(connection.sshUser)@\(connection.sshHost)"
+            ]
+        } else {
+            // Key-file mode: write a temp askpass script if a passphrase is provided.
+            if let passphrase, !passphrase.isEmpty {
+                askpassURL = try Self.writeAskpassScript(passphrase: passphrase)
+            }
+            p.arguments = [
+                "-N",
+                "-L", "\(localPort):\(connection.host):\(connection.port)",
+                "-p", "\(connection.sshPort)",
+                "-i", connection.sshKeyPath,
+                "-o", "StrictHostKeyChecking=accept-new",
+                "-o", "ExitOnForwardFailure=yes",
+                "-o", "BatchMode=\(passphrase == nil || passphrase!.isEmpty ? "yes" : "no")",
+                "-o", "ServerAliveInterval=30",
+                "\(connection.sshUser)@\(connection.sshHost)"
+            ]
+            if let url = askpassURL {
+                env["SSH_ASKPASS"]         = url.path
+                env["SSH_ASKPASS_REQUIRE"] = "force"
+                env["DISPLAY"]             = ":0"
+            }
         }
         let stderrPipe   = Pipe()
         p.environment    = env

--- a/Tusk/Database/SSHTunnel.swift
+++ b/Tusk/Database/SSHTunnel.swift
@@ -32,6 +32,7 @@ actor SSHTunnel {
                 "-N",
                 "-L", "\(localPort):\(connection.host):\(connection.port)",
                 "-p", "\(connection.sshPort)",
+                "-o", "BatchMode=yes",
                 "-o", "StrictHostKeyChecking=accept-new",
                 "-o", "ExitOnForwardFailure=yes",
                 "-o", "ServerAliveInterval=30",

--- a/Tusk/Models/Connection.swift
+++ b/Tusk/Models/Connection.swift
@@ -30,6 +30,7 @@ struct Connection: Identifiable, Codable, Hashable, Sendable {
     var sshPort: Int = 22
     var sshUser: String = ""
     var sshKeyPath: String = ""
+    var sshUseAgent: Bool = false   // use SSH agent ($SSH_AUTH_SOCK) instead of a key file
 
     // Google Cloud SQL
     var connectionType: ConnectionType = .direct
@@ -67,6 +68,7 @@ extension Connection {
         sshPort     = try c.decodeIfPresent(Int.self,     forKey: .sshPort)     ?? 22
         sshUser     = try c.decodeIfPresent(String.self,  forKey: .sshUser)     ?? ""
         sshKeyPath  = try c.decodeIfPresent(String.self,  forKey: .sshKeyPath)  ?? ""
+        sshUseAgent = try c.decodeIfPresent(Bool.self,    forKey: .sshUseAgent) ?? false
         connectionType                 = try c.decodeIfPresent(ConnectionType.self, forKey: .connectionType)                 ?? .direct
         cloudSQLInstanceConnectionName = try c.decodeIfPresent(String.self,         forKey: .cloudSQLInstanceConnectionName) ?? ""
         cloudSQLProject                = try c.decodeIfPresent(String.self,         forKey: .cloudSQLProject)                ?? ""

--- a/Tusk/Views/Sidebar/AddConnectionSheet.swift
+++ b/Tusk/Views/Sidebar/AddConnectionSheet.swift
@@ -29,6 +29,7 @@ struct AddConnectionSheet: View {
     @State private var sshUser: String = ""
     @State private var sshKeyPath: String = ""
     @State private var sshPassphrase: String = ""
+    @State private var sshUseAgent: Bool = false
 
     // Cloud SQL fields
     @State private var cloudSQLInstanceConnectionName: String = ""
@@ -62,7 +63,7 @@ struct AddConnectionSheet: View {
         [connectionType.rawValue,
          host, port, database, username, password,
          useSSL ? "ssl" : "", useSSL && verifySSLCertificate ? "verify" : "",
-         sshEnabled ? "ssh" : "", sshHost, sshPort, sshUser, sshKeyPath, sshPassphrase,
+         sshEnabled ? "ssh" : "", sshHost, sshPort, sshUser, sshKeyPath, sshPassphrase, sshUseAgent ? "agent" : "",
          cloudSQLInstanceConnectionName, useADC ? "adc" : ""].joined(separator: "|")
     }
 
@@ -249,12 +250,19 @@ struct AddConnectionSheet: View {
                                     .frame(width: 70)
                             }
                             TextField("User", text: $sshUser)
-                            HStack {
-                                TextField("Key Path", text: $sshKeyPath)
-                                Button("Browse…") { pickKey() }
-                                    .buttonStyle(.borderless)
+                            Picker("Auth", selection: $sshUseAgent) {
+                                Text("Private Key").tag(false)
+                                Text("SSH Agent").tag(true)
                             }
-                            SecureField("Passphrase", text: $sshPassphrase)
+                            .help("SSH Agent uses $SSH_AUTH_SOCK (1Password, Secretive, ssh-agent). Private Key uses a key file on disk.")
+                            if !sshUseAgent {
+                                HStack {
+                                    TextField("Key Path", text: $sshKeyPath)
+                                    Button("Browse…") { pickKey() }
+                                        .buttonStyle(.borderless)
+                                }
+                                SecureField("Passphrase", text: $sshPassphrase)
+                            }
                         }
                     }
                 }
@@ -336,6 +344,7 @@ struct AddConnectionSheet: View {
         sshUser         = c.sshUser
         sshKeyPath      = c.sshKeyPath
         sshPassphrase   = KeychainManager.shared.sshPassphrase(for: c.id) ?? ""
+        sshUseAgent     = c.sshUseAgent
         notes           = c.notes
         cloudSQLInstanceConnectionName = c.cloudSQLInstanceConnectionName
         cloudSQLProject = c.cloudSQLProject
@@ -382,6 +391,7 @@ struct AddConnectionSheet: View {
             updated.sshPort      = sshPortInt
             updated.sshUser      = sshUser
             updated.sshKeyPath   = sshKeyPath
+            updated.sshUseAgent  = sshUseAgent
             updated.notes        = notes
             updated.cloudSQLInstanceConnectionName = cloudSQLInstanceConnectionName
             updated.cloudSQLProject = cloudSQLProject
@@ -407,6 +417,7 @@ struct AddConnectionSheet: View {
             new.notes       = notes
             new.sshUser     = sshUser
             new.sshKeyPath  = sshKeyPath
+            new.sshUseAgent = sshUseAgent
             new.cloudSQLInstanceConnectionName = cloudSQLInstanceConnectionName
             new.cloudSQLProject = cloudSQLProject
             new.useADC      = useADC
@@ -498,11 +509,12 @@ struct AddConnectionSheet: View {
             database: database, username: username,
             useSSL: useSSL, verifySSLCertificate: verifySSLCertificate, isReadOnly: isReadOnly
         )
-        info.sshEnabled = sshEnabled
-        info.sshHost    = sshHost
-        info.sshPort    = Int(sshPort) ?? 22
-        info.sshUser    = sshUser
-        info.sshKeyPath = sshKeyPath
+        info.sshEnabled  = sshEnabled
+        info.sshHost     = sshHost
+        info.sshPort     = Int(sshPort) ?? 22
+        info.sshUser     = sshUser
+        info.sshKeyPath  = sshKeyPath
+        info.sshUseAgent = sshUseAgent
 
         var tunnel: SSHTunnel? = nil
 
@@ -511,7 +523,7 @@ struct AddConnectionSheet: View {
                 let t = SSHTunnel()
                 try await t.start(
                     connection: info,
-                    passphrase: sshPassphrase.isEmpty ? nil : sshPassphrase
+                    passphrase: sshUseAgent || sshPassphrase.isEmpty ? nil : sshPassphrase
                 )
                 tunnel    = t
                 info.host = "127.0.0.1"

--- a/Tusk/Views/Sidebar/AddConnectionSheet.swift
+++ b/Tusk/Views/Sidebar/AddConnectionSheet.swift
@@ -401,7 +401,11 @@ struct AddConnectionSheet: View {
             } else {
                 KeychainManager.shared.setPassword(password, for: updated.id)
             }
-            KeychainManager.shared.setSshPassphrase(sshPassphrase, for: updated.id)
+            if sshUseAgent {
+                KeychainManager.shared.deleteSshPassphrase(for: updated.id)
+            } else {
+                KeychainManager.shared.setSshPassphrase(sshPassphrase, for: updated.id)
+            }
             appState.updateConnection(updated)
         } else {
             var new = Connection(
@@ -426,7 +430,9 @@ struct AddConnectionSheet: View {
             } else {
                 KeychainManager.shared.setPassword(password, for: new.id)
             }
-            KeychainManager.shared.setSshPassphrase(sshPassphrase, for: new.id)
+            if !sshUseAgent {
+                KeychainManager.shared.setSshPassphrase(sshPassphrase, for: new.id)
+            }
             appState.addConnection(new)
         }
         dismiss()

--- a/Tusk/Views/Sidebar/AddConnectionSheet.swift
+++ b/Tusk/Views/Sidebar/AddConnectionSheet.swift
@@ -343,8 +343,8 @@ struct AddConnectionSheet: View {
         sshPort         = String(c.sshPort)
         sshUser         = c.sshUser
         sshKeyPath      = c.sshKeyPath
-        sshPassphrase   = KeychainManager.shared.sshPassphrase(for: c.id) ?? ""
         sshUseAgent     = c.sshUseAgent
+        sshPassphrase   = c.sshUseAgent ? "" : (KeychainManager.shared.sshPassphrase(for: c.id) ?? "")
         notes           = c.notes
         cloudSQLInstanceConnectionName = c.cloudSQLInstanceConnectionName
         cloudSQLProject = c.cloudSQLProject


### PR DESCRIPTION
## Summary
- Adds SSH agent auth mode for SSH tunnels — select "SSH Agent" in the connection sheet to use \$SSH_AUTH_SOCK (1Password, Secretive, ssh-agent) instead of a key file
- `SSHTunnel` branches on `sshUseAgent`: agent mode omits `-i` and includes `BatchMode=yes` to fail fast when the agent has no valid identity; key-file mode is unchanged
- Keychain passphrase is skipped on lookup and write when in agent mode; switching to agent deletes any stored passphrase

## Issues
Closes #199

## Test plan
- [ ] Add a connection with SSH tunnel, select "SSH Agent" — key path and passphrase fields should hide
- [ ] With a running SSH agent (or 1Password SSH), connect — tunnel should establish and DB should be reachable
- [ ] With no SSH agent running (`SSH_AUTH_SOCK` unset), connect — should get a clear error "SSH_AUTH_SOCK is not set…"
- [ ] With agent running but no identity loaded for the target host, connect — should fail quickly with an auth error rather than hanging 15 seconds
- [ ] Select "Private Key" — key path and passphrase fields should reappear; existing key-file behaviour unchanged
- [ ] Edit an existing connection, toggle to SSH Agent, save — verify passphrase is removed from Keychain