### PR TITLE
Fix numeric results and query tab focus

### DIFF
--- a/.codex/skills/tusk-make-clean/SKILL.md
+++ b/.codex/skills/tusk-make-clean/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: tusk-make-clean
+description: "Use when the user asks to run `make clean` for the Tusk macOS project or diagnose failures while cleaning Xcode build artifacts."
+---
+
+# Tusk Make Clean
+
+Run `make clean` to remove Xcode build artifacts for the Tusk project.
+
+## Steps
+
+### 1. Run Clean
+
+```sh
+make clean
+```
+
+Capture the full output.
+
+### 2. Evaluate Result
+
+If the command exits successfully and `** CLEAN SUCCEEDED **` appears, report success concisely.
+
+If the command fails or produces errors:
+
+1. Read the error output carefully.
+2. Identify the root cause, such as a missing project file, unavailable `xcodebuild`, scheme mismatch, or DerivedData permission issue.
+3. Present the user with a one-line summary, the specific error line or lines, and concrete recommended actions.
+
+Do not auto-fix clean failures unless the user explicitly asks for repairs.

--- a/.codex/skills/tusk-make-run/SKILL.md
+++ b/.codex/skills/tusk-make-run/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: tusk-make-run
+description: "Use when the user asks to run `make run` for the Tusk macOS project, build and launch the app, or diagnose build and launch failures."
+---
+
+# Tusk Make Run
+
+Run `make run` to build and launch the Tusk app. This kills any running Tusk instance, builds the project, and opens the freshly built app.
+
+## Steps
+
+### 1. Run
+
+```sh
+make run
+```
+
+Capture the full output.
+
+### 2. Evaluate Result
+
+If the command succeeds, `** BUILD SUCCEEDED **` appears, and the app opens, report success concisely.
+
+If the command fails or produces errors:
+
+1. Read the error output carefully.
+2. Identify the root cause.
+3. Present the user with a one-line summary, the specific error line or lines, and concrete recommended actions.
+
+Common failure categories:
+
+- Compile errors: pinpoint the Swift or Objective-C file and line.
+- Linker errors: identify missing frameworks or libraries.
+- Code signing or provisioning errors: call out expired certificates, missing entitlements, or provisioning issues.
+- Missing generated files: `project.yml` may be out of sync and `xcodegen generate` may be needed.
+- Missing `xcodebuild`: Xcode may be absent or `xcode-select` may point to the wrong path.
+- App launch failure: the build succeeded but `open` failed due to the app path or sandbox state.
+
+Do not auto-fix run failures unless the user explicitly asks for repairs.

--- a/.codex/skills/tusk-release/SKILL.md
+++ b/.codex/skills/tusk-release/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: tusk-release
+description: "Use when preparing a full Tusk macOS release: bump the app version, regenerate the Xcode project, build and package the DMG, publish the GitHub release, and update README links."
+---
+
+# Tusk Release
+
+Perform a full release of Tusk. Work directly on `main`; do not create a feature branch for releases.
+
+## Version
+
+Use the version provided by the user. If no version is provided, derive one with the `YYYY.MM.DD-NN` scheme:
+
+1. Get today's date with `date +%Y.%m.%d`.
+2. List existing tags for today with `git tag | grep "^v$(date +%Y.%m.%d)-"`.
+3. If there are no tags for today, use `YYYY.MM.DD-00`.
+4. If tags exist, increment the zero-padded counter.
+5. Confirm the derived version with the user before proceeding.
+
+## Workflow
+
+### 1. Verify Starting State
+
+- Run `git pull`.
+- Confirm the current branch is `main`.
+- Confirm the working tree is clean.
+- If the branch is not `main` or the working tree is dirty, stop and report what the user needs to resolve.
+
+### 2. Bump Version
+
+Read the current values first, then update:
+
+- `Tusk/Resources/Info.plist`: set `CFBundleShortVersionString` to the release version and increment `CFBundleVersion` by 1.
+- `project.yml`: update the same two keys under `info:`.
+- `README.md`: update both the displayed DMG filename and URL path, including `v<version>/Tusk-<version>.dmg`.
+
+### 3. Regenerate Xcode Project
+
+```sh
+xcodegen generate
+```
+
+### 4. Build Release
+
+```sh
+xcodebuild -project Tusk.xcodeproj -scheme Tusk -configuration Release -destination "platform=macOS" build
+```
+
+Confirm `** BUILD SUCCEEDED **` before continuing.
+
+### 5. Package DMG
+
+Get the built app path:
+
+```sh
+xcodebuild -project Tusk.xcodeproj -scheme Tusk -configuration Release -showBuildSettings | awk '$1 == "BUILT_PRODUCTS_DIR" {print $3}'
+```
+
+Replace the staged app with a fresh copy:
+
+```sh
+rm -rf dist/dmg-staging/Tusk.app
+cp -R "$BUILT_PRODUCTS_DIR/Tusk.app" dist/dmg-staging/
+```
+
+Verify the staged app version:
+
+```sh
+defaults read "$(pwd)/dist/dmg-staging/Tusk.app/Contents/Info.plist" CFBundleShortVersionString
+```
+
+Check whether the DMG already exists:
+
+```sh
+ls dist/Tusk-<version>.dmg 2>/dev/null && echo "DMG already exists - stop" || echo "OK"
+```
+
+If it exists, stop and ask the user before overwriting. Otherwise create it:
+
+```sh
+hdiutil create -volname "Tusk" -srcfolder dist/dmg-staging -ov -format UDZO dist/Tusk-<version>.dmg
+```
+
+### 6. Commit, Tag, And Push
+
+```sh
+git add Tusk/Resources/Info.plist project.yml Tusk.xcodeproj README.md
+git commit -m "chore: bump version to <version>"
+git tag v<version>
+git push
+git push origin v<version>
+```
+
+### 7. Create GitHub Release
+
+Summarize commits since the previous tag into release notes:
+
+- `feat:` commits under **Features**
+- `fix:` commits under **Fixes**
+- design changes under **Design**
+- everything else under **Other**
+
+Always append this footer:
+
+```md
+---
+
+> Not notarized. On first launch right-click -> **Open**, or run:
+> ```
+> xattr -d com.apple.quarantine /Applications/Tusk.app
+> ```
+```
+
+Create the release:
+
+```sh
+gh release create v<version> dist/Tusk-<version>.dmg \
+  --title "Tusk <version>" \
+  --notes "<release notes>"
+```
+
+### 8. Confirm
+
+Report the GitHub release URL and confirm all release steps completed successfully.

--- a/Tusk/AppState.swift
+++ b/Tusk/AppState.swift
@@ -629,6 +629,7 @@ final class AppState {
         var queryTab = QueryTab()
         queryTab.connectionID = connection.id
         queryTab.connectionName = connection.name
+        queryTab.focusRequestID = UUID()
         queryTabs.append(queryTab)
 
         let detailTab = DetailTab(
@@ -639,6 +640,12 @@ final class AppState {
         )
         openTabs.append(detailTab)
         activateDetailTab(detailTab)
+    }
+
+    func clearQueryTabFocusRequest(tabID: UUID, requestID: UUID) {
+        guard let idx = queryTabs.firstIndex(where: { $0.id == tabID }),
+              queryTabs[idx].focusRequestID == requestID else { return }
+        queryTabs[idx].focusRequestID = nil
     }
 
     func closeDetailTab(_ tabID: UUID) {
@@ -777,6 +784,7 @@ struct QueryTab: Identifiable {
     var sql: String = ""
     var sourceURL: URL? = nil
     var executions: [ExecutionEntry] = []
+    var focusRequestID: UUID? = nil
 }
 
 // MARK: - Detail tab model

--- a/Tusk/Database/DatabaseClient.swift
+++ b/Tusk/Database/DatabaseClient.swift
@@ -820,6 +820,10 @@ private func pgCellString(bytes: ByteBuffer, dataType: PostgresDataType) -> Stri
         guard let bits = buf.readInteger(as: UInt64.self) else { break }
         return String(Double(bitPattern: bits))
 
+    case .numeric:
+        guard let numeric = pgNumericString(bytes: bytes) else { break }
+        return numeric
+
     case .uuid:
         guard let b = buf.readBytes(length: 16) else { break }
         let t: uuid_t = (b[0],  b[1],  b[2],  b[3],
@@ -905,8 +909,84 @@ private func pgCellString(bytes: ByteBuffer, dataType: PostgresDataType) -> Stri
         break
     }
 
-    // Remaining types (text, varchar, json, numeric, …): UTF-8 text from the server
+    // Remaining types (text, varchar, json, …): UTF-8 text from the server
     return bytes.getString(at: bytes.readerIndex, length: bytes.readableBytes) ?? ""
+}
+
+/// Decodes PostgreSQL's binary `numeric` format into its display string.
+private func pgNumericString(bytes: ByteBuffer) -> String? {
+    var buf = bytes
+    guard let ndigitsRaw = buf.readInteger(endianness: .big, as: Int16.self),
+          let weight = buf.readInteger(endianness: .big, as: Int16.self),
+          let sign = buf.readInteger(endianness: .big, as: Int16.self),
+          let dscaleRaw = buf.readInteger(endianness: .big, as: Int16.self),
+          ndigitsRaw >= 0,
+          dscaleRaw >= 0 else { return nil }
+
+    switch UInt16(bitPattern: sign) {
+    case 0xC000: return "NaN"
+    case 0xD000: return "Infinity"
+    case 0xF000: return "-Infinity"
+    default: break
+    }
+
+    let ndigits = Int(ndigitsRaw)
+    let dscale = Int(dscaleRaw)
+    guard buf.readableBytes >= ndigits * MemoryLayout<Int16>.size else { return nil }
+
+    var digits: [Int] = []
+    digits.reserveCapacity(ndigits)
+    for _ in 0..<ndigits {
+        guard let digit = buf.readInteger(endianness: .big, as: Int16.self),
+              digit >= 0,
+              digit < 10_000 else { return nil }
+        digits.append(Int(digit))
+    }
+
+    guard !digits.isEmpty else {
+        return dscale > 0 ? "0." + String(repeating: "0", count: dscale) : "0"
+    }
+
+    var integer = ""
+    var fractional = ""
+
+    for (offset, digit) in digits.enumerated() {
+        let group = offset == 0 && weight >= 0
+            ? String(digit)
+            : String(format: "%04d", digit)
+        if Int(weight) - offset >= 0 {
+            integer += group
+        } else {
+            fractional += group
+        }
+    }
+
+    let missingGroups: Int
+    if weight > 0 {
+        missingGroups = Int(weight) + 1 - ndigits
+    } else if weight < 0 {
+        missingGroups = abs(Int(weight) + 1)
+    } else {
+        missingGroups = 0
+    }
+
+    if missingGroups > 0 {
+        if weight > 0 {
+            integer += String(repeating: "0000", count: missingGroups)
+        } else {
+            fractional = String(repeating: "0000", count: missingGroups) + fractional
+        }
+    }
+
+    if integer.isEmpty { integer = "0" }
+    if fractional.count < dscale {
+        fractional += String(repeating: "0", count: dscale - fractional.count)
+    } else if fractional.count > dscale {
+        fractional = String(fractional.prefix(dscale))
+    }
+
+    let numeric = fractional.isEmpty ? integer : "\(integer).\(fractional)"
+    return (UInt16(bitPattern: sign) & 0x4000) != 0 ? "-\(numeric)" : numeric
 }
 
 /// Formats microseconds-since-midnight as `HH:MM:SS[.ffffff]`.

--- a/Tusk/Views/Main/QueryEditorView.swift
+++ b/Tusk/Views/Main/QueryEditorView.swift
@@ -138,7 +138,14 @@ struct QueryEditorView: View {
             Divider()
 
             ZStack(alignment: .topLeading) {
-                SQLTextEditor(text: $sql, selectedRange: $selectedRange, fontSize: contentFontSize)
+                SQLTextEditor(
+                    text: $sql,
+                    selectedRange: $selectedRange,
+                    fontSize: contentFontSize,
+                    focusRequestID: tab.focusRequestID
+                ) { requestID in
+                    appState.clearQueryTabFocusRequest(tabID: tab.id, requestID: requestID)
+                }
                 if sql.isEmpty {
                     Text("-- Write SQL here · ⌘↵ to run · ⌘⇧↵ for current")
                         .font(.system(size: contentFontSize, design: .monospaced))

--- a/Tusk/Views/Main/SQLTextEditor.swift
+++ b/Tusk/Views/Main/SQLTextEditor.swift
@@ -7,18 +7,24 @@ struct SQLTextEditor: NSViewRepresentable {
     @Binding var selectedRange: NSRange
     var fontSize: Double = Double(NSFont.systemFontSize)
     var isEditable: Bool = true
+    var focusRequestID: UUID?
+    var onFocusRequestHandled: (@MainActor (UUID) -> Void)?
 
     /// Convenience init so existing call sites that don't need selectedRange compile unchanged.
     init(
         text: Binding<String>,
         selectedRange: Binding<NSRange> = .constant(NSRange()),
         fontSize: Double = Double(NSFont.systemFontSize),
-        isEditable: Bool = true
+        isEditable: Bool = true,
+        focusRequestID: UUID? = nil,
+        onFocusRequestHandled: (@MainActor (UUID) -> Void)? = nil
     ) {
         _text = text
         _selectedRange = selectedRange
         self.fontSize = fontSize
         self.isEditable = isEditable
+        self.focusRequestID = focusRequestID
+        self.onFocusRequestHandled = onFocusRequestHandled
     }
 
     func makeNSView(context: Context) -> NSScrollView {
@@ -56,6 +62,7 @@ struct SQLTextEditor: NSViewRepresentable {
             textView.textStorage?.delegate = context.coordinator
         }
         textView.typingAttributes = baseTypingAttributes
+        context.coordinator.focusIfNeeded(textView)
 
         return scrollView
     }
@@ -63,6 +70,7 @@ struct SQLTextEditor: NSViewRepresentable {
     func updateNSView(_ nsView: NSScrollView, context: Context) {
         context.coordinator.parent = self
         guard let textView = nsView.documentView as? NSTextView else { return }
+        context.coordinator.focusIfNeeded(textView)
         // Re-apply font if it changed (e.g. user adjusted content font size setting)
         if textView.font != editorFont, let storage = textView.textStorage {
             textView.font = editorFont
@@ -86,8 +94,23 @@ struct SQLTextEditor: NSViewRepresentable {
     @MainActor
     final class Coordinator: NSObject, NSTextViewDelegate, @preconcurrency NSTextStorageDelegate {
         var parent: SQLTextEditor
+        private var handledFocusRequestID: UUID?
 
         init(_ parent: SQLTextEditor) { self.parent = parent }
+
+        func focusIfNeeded(_ textView: NSTextView) {
+            guard let requestID = parent.focusRequestID,
+                  handledFocusRequestID != requestID else { return }
+            Task { @MainActor [weak textView, weak self] in
+                guard let self,
+                      let textView,
+                      let window = textView.window,
+                      self.handledFocusRequestID != requestID else { return }
+                self.handledFocusRequestID = requestID
+                window.makeFirstResponder(textView)
+                self.parent.onFocusRequestHandled?(requestID)
+            }
+        }
 
         // MARK: - NSTextStorageDelegate
 

--- a/rules.dev-review.yaml
+++ b/rules.dev-review.yaml
@@ -1,0 +1,93 @@
+rules:
+  - id: no-main-thread-blocking-work
+    severity: high
+    category: Performance
+    applies_to:
+      - "Tusk/**/*.swift"
+    description: "Flag newly introduced synchronous file, network, database, process, or expensive parsing work on the main actor or inside SwiftUI body/update paths. Prefer async work, Task.detached for CPU/file work, or existing actor APIs."
+    examples:
+      - "String(contentsOf:) directly in a View body or @MainActor method."
+      - "Running Process synchronously from a button action without async isolation."
+
+  - id: preserve-appkit-focus-lifecycle
+    severity: medium
+    category: Edge Case
+    applies_to:
+      - "Tusk/Views/**/*.swift"
+    description: "When changes bridge SwiftUI and AppKit focus or first responder state, verify focus requests are one-shot, occur only after the NSView has a window, and do not steal focus during ordinary tab switches or view updates."
+
+  - id: respect-task-cancellation
+    severity: medium
+    category: Logic
+    applies_to:
+      - "Tusk/**/*.swift"
+    description: "Flag new async tasks that can outlive their view, tab, or connection without cancellation checks, cleanup, or state guards before writing back to AppState or @State."
+
+  - id: avoid-stale-appstate-writes
+    severity: medium
+    category: Edge Case
+    applies_to:
+      - "Tusk/AppState.swift"
+      - "Tusk/Views/**/*.swift"
+    description: "Flag writes to AppState or tab state that do not re-check the target id still exists after an async boundary or delayed callback."
+
+  - id: protect-secret-material
+    severity: high
+    category: Security
+    applies_to:
+      - "Tusk/Database/**/*.swift"
+      - "Tusk/Views/Sidebar/**/*.swift"
+    description: "Flag logging, pasteboard copying, UI echoing, or persistent storage of passwords, SSH passphrases, Cloud SQL tokens, connection URLs with credentials, or keychain-derived values."
+
+  - id: parameterize-user-controlled-sql
+    severity: high
+    category: Security
+    applies_to:
+      - "Tusk/**/*.swift"
+    description: "Flag SQL built from user-controlled values without parameters or project quoting helpers. Identifier interpolation must use quoteIdentifier; literal interpolation must use parameters where available or explicit escaping where parameters are not supported."
+
+  - id: confirm-destructive-database-actions
+    severity: high
+    category: UX
+    applies_to:
+      - "Tusk/Views/**/*.swift"
+      - "Tusk/Database/**/*.swift"
+    description: "Flag newly introduced destructive database actions such as DROP, DELETE, TRUNCATE, ALTER destructive changes, role removal, or connection deletion when they can run without a clear confirmation or undo-safe workflow."
+
+  - id: preserve-postgres-binary-decoding
+    severity: high
+    category: Logic
+    applies_to:
+      - "Tusk/Database/DatabaseClient.swift"
+      - "Tusk/Models/QueryResult.swift"
+    description: "For changes to query result decoding or export, verify PostgreSQL binary formats are decoded explicitly for non-text types and that NULL, numeric scale, date/time precision, booleans, UUIDs, and binary data keep their intended display/export semantics."
+
+  - id: avoid-swiftui-state-reset-regressions
+    severity: medium
+    category: Logic
+    applies_to:
+      - "Tusk/Views/**/*.swift"
+    description: "Flag changes that may reset editor text, result selections, split positions, loading state, or table browsing state on ordinary SwiftUI re-render, tab switch, or connection picker updates."
+
+  - id: maintain-keyboard-first-workflows
+    severity: medium
+    category: UX
+    applies_to:
+      - "Tusk/Views/**/*.swift"
+    description: "Flag changes that break documented keyboard workflows, especially Cmd-T new query tab, Cmd-Return run, Cmd-Shift-Return run current query, Cmd-W close tab, Cmd-[ and Cmd-] tab navigation, Escape/cancel flows, and focus visibility."
+
+  - id: avoid-unbounded-result-work
+    severity: medium
+    category: Performance
+    applies_to:
+      - "Tusk/Database/**/*.swift"
+      - "Tusk/Views/Main/**/*.swift"
+      - "Tusk/Models/QueryResult.swift"
+    description: "Flag changes that materialize, copy, sort, stringify, or render unbounded query result data on the main actor without row limits, background work, or explicit user action."
+
+  - id: surface-user-facing-errors
+    severity: medium
+    category: Error Handling
+    applies_to:
+      - "Tusk/**/*.swift"
+    description: "Flag newly swallowed errors in user-triggered workflows when the user would be left without feedback, especially connection, query execution, import/export, keychain, Cloud SQL, and file operations."


### PR DESCRIPTION
## Summary
- Decode PostgreSQL binary `numeric` values into display-safe decimal strings for result grids and copied CSV.
- Preserve numeric scale for values such as `0.0000`, `0`, and `0.00`.
- Focus the SQL editor automatically when a new query tab is opened with `⌘T`.

## Issues
Closes #224
Closes #225

## Test plan
- [x] Build succeeds with `xcodebuild -project Tusk.xcodeproj -scheme Tusk -configuration Debug -destination "platform=macOS" build`
- [x] Open a new query tab with `⌘T` and verify typing goes directly into the SQL editor.
- [x] Run the numeric reproduction query and verify copied CSV contains `0.0000`, `NULL`, `0`, and `0.00`.
- [x] Run `dev-review`; no issues found.
